### PR TITLE
fix(mosquitto): back data dir with a volsync PVC (was emptyDir — data loss)

### DIFF
--- a/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
@@ -100,6 +100,6 @@ spec:
         globalMounts:
           - path: /mosquitto-init
       data:
-        type: emptyDir
+        existingClaim: *app
         globalMounts:
           - path: /mosquitto/data

--- a/kubernetes/apps/database/mosquitto/ks.yaml
+++ b/kubernetes/apps/database/mosquitto/ks.yaml
@@ -10,6 +10,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
   dependsOn:
     - name: external-secrets-stores
       namespace: external-secrets
@@ -22,3 +24,11 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_SCHEDULE: "15 0 * * *"
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "1883"
+      VOLSYNC_GID: "1883"
+      VOLSYNC_FSGROUP: "1883"


### PR DESCRIPTION
Tier-2 (data protection) from the infrastructure audit.

## Problem
`mosquitto.conf` sets `persistence true` with `persistence_location /mosquitto/data/`, but `/mosquitto/data` was an **`emptyDir`**. So the retained-message / persistent-session DB (`mosquitto.db`) was silently discarded on every pod restart or reschedule. Mosquitto is the MQTT backbone for Zigbee2MQTT, Home Assistant, ratgdo, rtlamr, etc., so retained device states were lost on each restart.

## Fix
- Mount `/mosquitto/data` on a PVC via `existingClaim` (same pattern as bazarr/homeassistant on app-template 5.0.1).
- Wire the shared `components/volsync` into the Kustomization: restic → Cloudflare R2, daily snapshot, mover runs as mosquitto's `1883` uid/gid/fsgroup, 1Gi capacity.

The `passwd` emptyDir is intentionally left alone — it's regenerated by the `init-passwords` container on every start.

## Validation
`kustomize build` (path + volsync component) renders cleanly: the `mosquitto` PVC, `ReplicationSource`/`ReplicationDestination`, unlock RBAC, and the R2 `ExternalSecret`; the HelmRelease mounts `existingClaim: mosquitto`.

## Out of scope / follow-up
- **External Postgres backup** (audit R2): authentik's bundled Postgres is already volsync-backed; **home-assistant** and **lubelog** use an *external* Postgres (host in 1Password) whose backup is outside this repo — please confirm it's backed up.
- Loki's single `filesystem` PVC remains unbacked (low value — logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)