### PR TITLE
ci: add workflow to enable Tailscale SSH on macOS self-hosted runner

### DIFF
--- a/.github/workflows/enable-ssh.yml
+++ b/.github/workflows/enable-ssh.yml
@@ -1,0 +1,18 @@
+---
+name: Enable Tailscale SSH
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  enable-ssh:
+    runs-on: [self-hosted, macOS]
+    steps:
+      - name: Preflight (user and tailscale path)
+        run: whoami && which tailscale || true
+
+      - name: Enable Tailscale SSH
+        run: echo "${{ secrets.SUDO_PASS }}" | sudo -S tailscale set --ssh
+
+      - name: Verify Tailscale status
+        run: echo "${{ secrets.SUDO_PASS }}" | sudo -S tailscale status


### PR DESCRIPTION
## Summary

Adds `.github/workflows/enable-ssh.yml`, a `workflow_dispatch`-only workflow to enable Tailscale SSH on the headless macOS (M4 Mac Mini) self-hosted runner, since the runner is the only available execution path on that machine.

The single job pins to `runs-on: [self-hosted, macOS]` and has three steps:
- **Preflight** — `whoami && which tailscale` so the log shows the runner user and the `tailscale` binary path.
- **Enable Tailscale SSH** — `echo "${{ secrets.SUDO_PASS }}" | sudo -S tailscale set --ssh` (sudo authenticated non-interactively from the `SUDO_PASS` repo secret, which GitHub masks in logs).
- **Verify** — `sudo -S tailscale status` to confirm SSH is advertised.

No `set -x`, and the secret is never echoed anywhere except the piped `sudo -S`.

## Notes / required follow-up

- **`workflow_dispatch` is only dispatchable once this workflow exists on the default branch (`main`).** Until this PR is merged, the GitHub API/UI cannot trigger it on the feature branch (404 — workflow not registered).
- Runner labels `self-hosted` + `macOS` are GitHub's automatic defaults for a self-hosted macOS runner; there was no existing workflow or runner config in the repo to confirm custom labels against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx82oiLPnZSbMvQ6QmrmzW)_