### PR TITLE
fix(reliability): drop CPU limits on gateway/ceph, add retryInterval (audit R4/M5)

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -10,6 +10,7 @@ spec:
     - name: external-secrets-stores
       namespace: external-secrets
   interval: 1h
+  retryInterval: 1m
   path: ./kubernetes/apps/flux-system/flux-instance/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -10,6 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 30m
+  retryInterval: 1m
   path: ./kubernetes/apps/flux-system/flux-operator/app
   prune: false
   sourceRef:

--- a/kubernetes/apps/kube-system/k8s-digester/ks.yaml
+++ b/kubernetes/apps/kube-system/k8s-digester/ks.yaml
@@ -11,6 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/kube-system/k8s-digester/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -50,5 +50,4 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 500m
             memory: 512Mi

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -11,6 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/network/envoy-gateway/app
   prune: true
   sourceRef:
@@ -34,6 +35,7 @@ spec:
   dependsOn:
     - name: envoy-gateway
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/network/envoy-gateway/gateways
   prune: true
   sourceRef:
@@ -57,6 +59,7 @@ spec:
   dependsOn:
     - name: envoy-gateway-gateways
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/network/envoy-gateway/policies
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/exporters/bazarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/bazarr-exporter/ks.yaml
@@ -11,6 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/observability/exporters/bazarr-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/exporters/jellyseerr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/jellyseerr-exporter/ks.yaml
@@ -16,6 +16,7 @@ spec:
     - name: external-secrets-stores
       namespace: external-secrets
   interval: 10m
+  retryInterval: 1m
   path: ./kubernetes/apps/observability/exporters/jellyseerr-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -89,21 +89,18 @@ spec:
             cpu: "500m"
             memory: "512Mi"
           limits:
-            cpu: "2000m"
             memory: "4Gi"
         mon:
           requests:
             cpu: "100m"
             memory: "128Mi"
           limits:
-            cpu: "500m"
             memory: "1Gi"
         mgr:
           requests:
             cpu: "100m"
             memory: "256Mi"
           limits:
-            cpu: "500m"
             memory: "1Gi"
         mds: *defaultResources
         rgw:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -20,6 +20,7 @@ spec:
     name: flux-system
   wait: true
   interval: 30m
+  retryInterval: 1m
   timeout: 5m
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/kustomization-kustomize-v1.json
@@ -43,4 +44,5 @@ spec:
     name: flux-system
   wait: true
   interval: 30m
+  retryInterval: 1m
   timeout: 15m


### PR DESCRIPTION
Closes the two remaining reliability nits from the infrastructure audit.

## R4 — remove CPU limits on throughput-sensitive infra
CPU *limits* cause CFS throttling under load; requests already handle scheduling/QoS. Removed the limit (kept requests + memory limit) on:
- **envoy-gateway** (was `cpu: 500m`) — now the production L7 data path
- **ceph osd** (was `2000m`), **mon** (`500m`), **mgr** (`500m`) — throttling OSDs stalls client I/O and recovery/rebalance exactly when headroom matters most

Deliberately left alone: `mds` (shares the `&defaultResources` anchor), `rgw`, `crashcollector` (small, not hot-path), and `jellyfin`'s CPU cap (intentional metal-07 thermal fix, `033f5b6d`).

## M5 — add `retryInterval` to the 7 stragglers
Failed applies now retry in `1m` instead of waiting a full `interval`. Files: `flux-operator`, `flux-instance`, `envoy-gateway` (×3 docs), `rook-ceph` + `rook-ceph-cluster` (×2), `k8s-digester`, `bazarr-exporter`, `jellyseerr-exporter`. Every Kustomization in `kubernetes/apps` now has a matching `retryInterval`.

## Validation
All 9 files parse; `kustomize build` on the rook-ceph cluster path succeeds; all pre-commit hooks (yamllint, JSON-schema, gitleaks) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)