### PR TITLE
fix(validation): unset inherited git env in the kustomize validate tasks

### DIFF
--- a/.taskfiles/validation/Taskfile.yaml
+++ b/.taskfiles/validation/Taskfile.yaml
@@ -107,6 +107,14 @@ tasks:
     cmds:
       - |
         echo "=== Validating Kustomize Builds ==="
+        # Overlays with remote resources (apps/kube-system/k8s-digester pulls
+        # google/k8s-digester.git) make kustomize shell out to git. Under the
+        # pre-push hook git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE, the
+        # child git inherits them, and `git remote add origin` then targets THIS
+        # repo instead of kustomize's temp clone:
+        #   error: remote origin already exists
+        # That fails the task on every push while passing when run by hand.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         errors=0
         find {{.KUBERNETES_DIR}} -type f -name kustomization.yaml \
           -not -path "*/components/*" | while read -r file; do
@@ -131,6 +139,9 @@ tasks:
     cmds:
       - |
         echo "=== Running Kubeconform ==="
+        # Same inherited-git-env problem as validate:kustomize above — this task
+        # shells out to `kustomize build` too. See the comment there.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         errors=0
         # Substitute the ${SECRET_*}/CILIUM_* placeholders before kubeconform so
         # HTTPRoute hostnames render to valid values and are actually VALIDATED


### PR DESCRIPTION
## Problem

The `pre-push` hook runs `validate:kustomize` and `validate:kubeconform` with `always_run: true`, so both build every overlay on every push.

`apps/kube-system/k8s-digester` pulls a remote resource:

```yaml
resources:
  - https://github.com/google/k8s-digester.git/manifests/?ref=v0.1.16
```

which makes kustomize shell out to `git`. Git exports `GIT_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` into hooks, the child `git` inherits them, and kustomize's `git remote add origin` runs against **this** repo instead of its own temp clone:

```
failed to run '/usr/bin/git remote add origin https://github.com/google/k8s-digester.git':
error: remote origin already exists.
```

The symptom is misleading — both tasks pass when run by hand and fail only under `git push`, which reads as flakiness. It's deterministic, and it blocks every push that reaches the hook.

## Fix

`unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX` at the top of each task, so the git subprocess starts from a clean context.

## Verification

Reproduced by exporting `GIT_DIR` and running each task — failed on `apps/kube-system/k8s-digester/app`, matching the push failure exactly. With the fix and `GIT_DIR` still exported:

```
=== validate:kustomize ===   ✓ All kustomizations build successfully
=== validate:kubeconform === ✓ Kubeconform validation passed
```

The push that created this branch is itself the end-to-end check — the hook ran and passed.

## Context

Found while pushing a fix for the `arc-runner` image (that PR follows). Both hook files are dated today, so this gate is new and likely hasn't been through a successful push yet.