### PR TITLE
fix(ci): restore the ARC runner image build and install gh

### DIFF
--- a/containers/arc-runner/Dockerfile
+++ b/containers/arc-runner/Dockerfile
@@ -1,4 +1,4 @@
-# Custom ARC runner with Android SDK
+# Custom ARC runner with Android SDK and the GitHub CLI
 # Based on the official GitHub Actions runner image
 
 # renovate: datasource=docker depName=ghcr.io/actions/actions-runner
@@ -41,5 +41,30 @@ RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
       "platforms;android-35"
 
 RUN chown -R runner:runner ${ANDROID_HOME}
+
+# GitHub CLI. The official actions-runner base image does not ship `gh`, but
+# every GitHub-hosted ubuntu-* image does — so workflows moved onto this pool
+# from `ubuntu-latest` bring `gh` calls with them and fail at job time with
+# `gh: command not found` (exit 127). Worse where the call is wrapped in
+# `2>/dev/null || true`: those degrade silently rather than going red.
+# (doorgames-io/blockhead lost 8 jobs to this, including its Sentry
+# crash-alert pipeline, which dropped alerts unnoticed for three days.)
+#
+# Installed from the release tarball rather than the cli.github.com apt repo:
+# the version stays pinned and renovate-visible, no extra keyring/source to
+# maintain, and one expression covers both build platforms via TARGETARCH.
+# Placed after the Android SDK layers so a gh bump doesn't invalidate them.
+#
+# The trailing `gh --version` fails the build here rather than at job time on a
+# runner — the check that would have caught this gap when the pool was created.
+#
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_CLI_VERSION="2.96.0"
+RUN gh_dir="/tmp/gh_${GH_CLI_VERSION}_linux_${TARGETARCH}" && \
+    wget -qO- "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m 0755 "${gh_dir}/bin/gh" /usr/local/bin/gh && \
+    rm -rf "${gh_dir}" && \
+    gh --version
 
 USER runner


### PR DESCRIPTION
> **Stacked on #1341** — based on `fix/pre-push-kustomize-gitdir` so this PR shows only the Dockerfile commit. GitHub will retarget it to `main` automatically once #1341 merges.

## Problem

The official `actions-runner` base image (`mcr.microsoft.com/dotnet/runtime-deps:8.0-noble`) installs `curl jq unzip git sudo` — but **not `gh`**. Every GitHub-hosted `ubuntu-*` image preinstalls it. So workflows moved onto the `arc-linux` pool carry `gh` calls with them and hit `gh: command not found` (exit 127).

`doorgames-io/blockhead` moved all its Linux jobs to this pool on 2026-07-27 and lost **8 jobs across 7 workflows** the next day. The loud failures were obvious. The quiet ones were not:

- Calls wrapped in `2>/dev/null || true` — the coverage and CI-status badge updates — simply stopped taking effect, with the job still green.
- Its Sentry crash-alert pipeline silently filed **nothing for three days**. The canary built to detect exactly that was itself too broken to report.

## Fix

Install a pinned `gh` from the release tarball, after the Android SDK layers.

Tarball rather than the `cli.github.com` apt repo:
- no extra keyring or apt source to maintain
- version stays pinned and renovate-visible via the `# renovate: datasource=github-releases depName=cli/cli` ARG comment, matching the existing `RUNNER_VERSION` pattern
- one expression covers both build platforms through the existing `TARGETARCH`

Placed after the Android SDK layers so a `gh` bump doesn't invalidate them. Ends in `gh --version`, so a broken install fails the image build instead of a job hours later — the check that would have caught this gap when the pool was created.

## Verification

- Confirmed absence at source in [upstream's Dockerfile](https://github.com/actions/runner/blob/main/images/Dockerfile), not just from CI logs
- Both release assets exist and extract to `gh_<ver>_linux_<arch>/bin/gh` — verified for `amd64` and `arm64`
- Upstream sets no `PATH` override, so `/usr/local/bin/gh` lands on the default PATH; it also uses the same `install -m 755` idiom
- `wget` is installed by this Dockerfile already; `tar`/`install` come from the Ubuntu base

The multi-arch build on this PR is the real end-to-end check — I have no Docker locally.

## Follow-up (not in this PR)

1. **The digest pin still needs bumping.** `kubernetes/apps/actions-runner-system/runners/app/helmrelease.yaml` pins `sha256-661e50e7…`, and that's a manual step here (cf. `2dbd47d7`). After this builds on `main`:
   ```
   docker buildx imagetools inspect ghcr.io/sob/arc-runner:rolling --format '{{json .}}' | jq -r '.manifest.digest'
   ```
2. **`python3` is missing too** — same gap, next binary over. `blockhead` works around it with an explicit `actions/setup-python`. Worth considering for this image.
3. `containers/{enigma-bbs,mysticbbs}/go.mod` both require `dockertest/v4` while their tests import `v3`, and each has a duplicated `require` line. I left them alone, but a container test asserting the toolchain contract is the thing that would keep this class of gap from recurring.