### PR TITLE
fix(ci): restore the ARC runner image build and install gh

### DIFF
--- a/containers/arc-runner/Dockerfile
+++ b/containers/arc-runner/Dockerfile
@@ -8,7 +8,12 @@ FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
 
 ARG ANDROID_CMDLINE_TOOLS_VERSION="11076708"
 ARG ANDROID_BUILD_TOOLS_VERSION="37.0.0"
-ARG ANDROID_PLATFORM_VERSION="37"
+# 36, not 37: Google publishes build-tools;37.0.0 but the highest platform in
+# the SDK repository is platforms;android-36. 631bdcad bumped both, so every
+# image build since 2026-07-17 has died here with
+#   Warning: Failed to find package 'platforms;android-37'
+# before reaching any later layer. Raise this to 37 once Google ships it.
+ARG ANDROID_PLATFORM_VERSION="36"
 
 USER root
 

--- a/containers/arc-runner/Dockerfile
+++ b/containers/arc-runner/Dockerfile
@@ -1,4 +1,4 @@
-# Custom ARC runner with Android SDK
+# Custom ARC runner with Android SDK and the GitHub CLI
 # Based on the official GitHub Actions runner image
 
 # renovate: datasource=docker depName=ghcr.io/actions/actions-runner
@@ -41,5 +41,30 @@ RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
       "platforms;android-35"
 
 RUN chown -R runner:runner ${ANDROID_HOME}
+
+# GitHub CLI. The official actions-runner base image does not ship `gh`, but
+# every GitHub-hosted ubuntu-* image does — so workflows moved onto this pool
+# from `ubuntu-latest` bring `gh` calls with them and fail at job time with
+# `gh: command not found` (exit 127). Worse where the call is wrapped in
+# `2>/dev/null || true`: those degrade silently rather than going red.
+# (doorgames-io/blockhead lost 8 jobs to this, including its Sentry
+# crash-alert pipeline, which dropped alerts unnoticed for three days.)
+#
+# Installed from the release tarball rather than the cli.github.com apt repo:
+# the version stays pinned and renovate-visible, no extra keyring/source to
+# maintain, and one expression covers both build platforms via TARGETARCH.
+# Placed after the Android SDK layers so a gh bump doesn't invalidate them.
+#
+# The trailing `gh --version` fails the build here rather than at job time on a
+# runner — the check that would have caught this gap when the pool was created.
+#
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_CLI_VERSION="2.96.0"
+RUN gh_dir="/tmp/gh_${GH_CLI_VERSION}_linux_${TARGETARCH}" && \
+    wget -qO- "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m 0755 "${gh_dir}/bin/gh" /usr/local/bin/gh && \
+    rm -rf "${gh_dir}" && \
+    gh --version
 
 USER runner


### PR DESCRIPTION
Supersedes #1342, which was merged into its stacked base (`fix/pre-push-kustomize-gitdir`) rather than `main`, so the `gh` fix never reached `main`. This PR re-targets it correctly and adds the build fix it needs.

Two commits, one file.

---

## 1. The image hasn't built since 2026-07-17

`631bdcad` raised both `ANDROID_BUILD_TOOLS_VERSION` and `ANDROID_PLATFORM_VERSION` to 37. Only the first is real — Google publishes `build-tools;37.0.0`, but the highest platform in the SDK repository index (`repository2-3.xml`) is `platforms;android-36`:

```
platforms;android-30 … 36     ← highest published
platforms;android-37          ← does not exist
```

So every `arc-runner` build since has failed, on both architectures:

```
Warning: Failed to find package 'platforms;android-37'
#12 ERROR: process "/bin/sh -c yes | sdkmanager --licenses ..." did not complete successfully: exit code: 1
```

That layer sits early in the image, so nothing after it is reached — and the runners are still on the pre-2026-07-17 digest. Dropped the platform to 36, left build-tools at 37.0.0 (published, and works against older platforms).

## 2. The runner image has no `gh`

The base image (`mcr.microsoft.com/dotnet/runtime-deps:8.0-noble`) installs `curl jq unzip git sudo` — but not `gh`. Every GitHub-hosted `ubuntu-*` image preinstalls it, so workflows moved onto `arc-linux` bring `gh` calls with them and hit `gh: command not found` (exit 127).

`doorgames-io/blockhead` moved all its Linux jobs to this pool on 2026-07-27 and lost **8 jobs across 7 workflows** the next day. The loud failures were obvious; the quiet ones were not:

- Calls wrapped in `2>/dev/null || true` — the coverage and CI-status badge updates — stopped taking effect while the job stayed green.
- Its Sentry crash-alert pipeline silently filed **nothing for three days**. The canary built to catch exactly that was itself too broken to report.

Installed from the pinned release tarball rather than the `cli.github.com` apt repo: no keyring or apt source to maintain, the version stays renovate-visible via the `# renovate: datasource=github-releases depName=cli/cli` ARG comment (matching the existing `RUNNER_VERSION` pattern), and one expression covers both platforms via `TARGETARCH`. Sits after the Android SDK layers so a `gh` bump doesn't invalidate them, and ends in `gh --version` so a broken install fails the build rather than a job hours later.

## Verification

- Absence of `gh` confirmed at source in [upstream's Dockerfile](https://github.com/actions/runner/blob/main/images/Dockerfile), not just inferred from CI logs
- Available Android packages read from Google's `repository2-3.xml` directly
- Both `gh` release assets exist and extract to `gh_<ver>_linux_<arch>/bin/gh` — checked `amd64` and `arm64`
- Upstream sets no `PATH` override, so `/usr/local/bin/gh` lands on the default PATH; it uses the same `install -m 755` idiom
- `wget` is already installed by this Dockerfile; `tar`/`install` come from the Ubuntu base

The multi-arch build on this PR is the real end-to-end check — I have no Docker locally.

## After merge

The digest pin is manual here (cf. `2dbd47d7`). Once this builds on `main`, bump `kubernetes/apps/actions-runner-system/runners/app/helmrelease.yaml` (currently `sha256-661e50e7…`):

```
docker buildx imagetools inspect ghcr.io/sob/arc-runner:rolling --format '{{json .}}' | jq -r '.manifest.digest'
```

## Cleanup / follow-ups

- `fix/pre-push-kustomize-gitdir` and `fix/arc-runner-gh-cli` are now orphaned and safe to delete — everything in them is either on `main` or in this PR.
- **`python3` is missing from this image too** — same gap, next binary over. `blockhead` works around it with an explicit `actions/setup-python`.
- `containers/{enigma-bbs,mysticbbs}/go.mod` both require `dockertest/v4` while their tests import `v3`, and each has a duplicated `require` line. A container test asserting this image's toolchain contract is what would stop this class of gap recurring.