### PR TITLE
fix(ci): roll ARC runners onto the image that has gh

### DIFF
--- a/kubernetes/apps/actions-runner-system/runners/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/runners/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: ghcr.io/sob/arc-runner:sha256-661e50e7ed3a77556b84dce014c9fccef1e7034ea6fc98a54a7947fd763716dc
+            image: ghcr.io/sob/arc-runner:sha256-96a5705d29f80f7c6227cafb9a1401af4141578bfe5fb91586af8651718bd1f4
             command: ["/home/runner/run.sh"]
             # Android builds observed to burst to ~3 cores / ~4.8Gi. Request a
             # realistic floor so the scheduler spreads runners (~2 per ~4-core


### PR DESCRIPTION
Final step of #1343 — the digest pin is manual in this repo (cf. `2dbd47d7`), so the new image doesn't reach the runners until this lands.

```
ghcr.io/sob/arc-runner:sha256-661e50e7…  →  sha256-96a5705d…
```

Built by [run 30546950896](https://github.com/sob/home-ops/actions/runs/30546950896) from `bc06d66c` (#1343): Android platform back to 36 so the image builds at all, plus pinned `gh` 2.96.0.

The outgoing digest predates 2026-07-17 — every build between then and #1343 died on the nonexistent `platforms;android-37`, so the runners have been ~2 weeks stale on top of missing `gh`.

## Verification before pinning

- Tag resolves in GHCR (anonymous pull token, `/v2/sob/arc-runner/tags/list`)
- It's an `application/vnd.oci.image.index.v1+json` carrying both platforms:
  ```
  linux/amd64  sha256:314854718bdd2bb2
  linux/arm64  sha256:17280104488098ad
  ```
- Both build legs printed `gh version 2.96.0 (2026-07-02)` from the Dockerfile's build-time assertion
- `task validate:kustomize` and `task validate:kubeconform` pass; rendered manifest carries the new digest

## After reconcile

Worth confirming the runner pods actually rolled — `minRunners: 1` keeps one warm, and existing ephemeral pods finish their current job on the old image first:

```
kubectl -n actions-runner-system get pods -o jsonpath='{.items[*].spec.containers[?(@.name=="runner")].image}'
```

The workaround install steps in `doorgames-io/blockhead` need no coordination — each is guarded by `command -v gh`, so they turn into no-ops once this is live, and stay as a guard if the image ever regresses.

## Still open

- `python3` is missing from this image too — same gap, next binary over.
- `fix/pre-push-kustomize-gitdir` and `fix/arc-runner-gh-cli` are orphaned and safe to delete.