### PR TITLE
fix(renovate): stop internal checks from blocking updates indefinitely

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,17 @@
     'prIgnoreNotification',
   ],
   rebaseWhen: 'behind-base-branch',
+  // NOTE: minimumReleaseAge needs a release timestamp. For datasource=docker that
+  // means walking the OCI index -> child manifest -> config blob for `created`.
+  // Multi-arch ghcr.io images that also publish unknown/unknown attestation
+  // manifests (gatus, tautulli, unpoller, ...) don't resolve reliably, so the age
+  // check could never pass and those updates sat in the dashboard's "Pending
+  // Status Checks" section forever. 'none' stops internal checks from filtering
+  // updates: PRs get created and CI + the automerge rules become the gate.
+  // Stability delays still apply to automerge decisions, and critical infra
+  // (rook/cilium/cert-manager/external-secrets/flux) is automerge:false anyway,
+  // so those still require a human to merge.
+  internalChecksFilter: 'none',
   prConcurrentLimit: 30,
   prHourlyLimit: 0,
   branchConcurrentLimit: 30,


### PR DESCRIPTION
## Problem

79 updates are parked in the Renovate dashboard (#137) under **Pending Status Checks**.

Despite the section name, none of these are waiting on GitHub CI. The Renovate run log stamps the flag directly onto the update objects:

```json
"newVersion": "2.13.0",
"updateType": "minor",
"pendingChecks": true,
"branchName": "renovate/ghcr.io-koenkk-zigbee2mqtt-2.x"
```

`pendingChecks` is Renovate's **internal** gate. The only one configured here is `minimumReleaseAge` — 3 days globally, with 1/5/7 day overrides in `renovate/autoMerge.json5`.

## Two populations

Some are legitimately inside the window and would clear on their own:

| package | latest | age |
|---|---|---|
| romm | 5.1.1-beta.1 | 1 day |
| zigbee2mqtt | 2.13.0 | 2 days |
| homarr | v1.73.0 | 3 days |

Others never could:

| package | latest | age |
|---|---|---|
| unpoller | v3.3.4 | 9 days |
| tautulli | v2.17.2 | 48 days |
| gatus | v5.36.0 | 76 days |

## Root cause

`minimumReleaseAge` needs a release timestamp. For `datasource: docker` that means walking the OCI index → child manifest → config blob to read `created`.

The affected images are multi-arch `ghcr.io` builds that also publish attestation manifests:

```
linux/amd64        oci.image.manifest.v1+json
linux/arm          oci.image.manifest.v1+json
linux/arm64        oci.image.manifest.v1+json
unknown/unknown    oci.image.manifest.v1+json   <- attestation
unknown/unknown    oci.image.manifest.v1+json   <- attestation
unknown/unknown    oci.image.manifest.v1+json   <- attestation
```

The timestamp does exist (`gatus v5.36.0` → `2026-05-19T23:55:54Z`, confirmed by hand-walking the index), but it doesn't resolve reliably through this shape. When it can't be resolved the age check can never pass, so the update sits pending permanently instead of failing visibly.

## Change

Set `internalChecksFilter: 'none'` so internal checks stop filtering updates. PRs get created, and CI plus the existing automerge rules become the gate.

This does make stability delays advisory for PR creation. No review step is lost:

- major updates still require dashboard approval (`dependencyDashboardApproval: true`)
- critical infra (rook, cilium, cert-manager, external-secrets, flux) is `automerge: false` and still needs a human to merge
- everything else still has to pass `Validate Success` before it can merge

## Context

The size of the backlog traces to d6a49dcb (2026-06-25), which slash-delimited `managerFilePatterns` so in-HelmRelease images were detected again. That's why the jumps are so large (`zigbee2mqtt 2.5.1 → 2.13.0`, `unpoller 2.11.2 → 3.3.4`). PR limits aren't binding — 3 open against `prConcurrentLimit: 30`.

## Not covered here

- 23 entries under **Pending Approval** are working as designed — majors need a checkbox.
- `renovate/media-downloaders` has stale failing checks under the pre-#1297 job names (`Validation Success`) while branch protection now requires `Validate Success`. It needs recreating.

## Verification

Renovate runs hourly. After merge, confirm the Pending Status Checks section on #137 drains and PRs appear for the aged updates (gatus, tautulli, unpoller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)