### PR TITLE
feat(container): update qbittorrent ( 5.1.2 → 5.2.3 )

### DIFF
--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/qbittorrent
-              tag: 5.1.2@sha256:9dd0164cc23e9c937e0af27fd7c3f627d1df30c182cf62ed34d3f129c55dc0e8
+              tag: 5.2.3@sha256:4fcf15b7f265c2c8d7bc2a7e13240a07e0593c326f3cf3b5b9bb69eec5b79299
             env:
               TZ: America/Chicago
               QBT_WEBUI_PORT: &port 80


### PR DESCRIPTION
Unblocks the `media-downloaders` group, which had been parked since 2026-06-25.

## Why the Renovate branch couldn't be salvaged

`renovate/media-downloaders` was cut when main still had **sabnzbd 4.4.1** and proposed 4.5.5. Main has since moved to **5.0.4**, so merging that branch would have regressed sabnzbd by a major version. It also still proposed qbittorrent 5.2.2 while 5.2.3 is out.

## Its CI failure was unrelated to the downloaders

The only *critical* failing job was `Flux Local Test` (YAML lint and schema validation are non-blocking there), and it failed on **plex**, not on qbittorrent or sabnzbd:

```
ERROR: Command 'flux build ks plex --dry-run ...' failed with return code 1
✗ var substitution failed for 'plex': envsubst error: YAMLToJSON: yaml: line 32: did not find expected node content
```

That has since been fixed on main — `Flux Local Test` now runs and passes on PRs touching `kubernetes/` (verified on run 30828995776).

## This change

| image | main | latest | action |
|---|---|---|---|
| `ghcr.io/home-operations/qbittorrent` | 5.1.2 | 5.2.3 | bumped |
| `ghcr.io/home-operations/sabnzbd` | 5.0.4 | 5.0.4 | already current |

Digest resolved from the registry: `sha256:4fcf15b7f265c2c8d7bc2a7e13240a07e0593c326f3cf3b5b9bb69eec5b79299`

## Validation

`task validate` passes locally — 171 flux-local tests, kustomize build, kubeconform, and OPA policies all green.

## Note

This is a **minor** bump (5.1 → 5.2), so worth a glance at qBittorrent's WebUI behaviour after rollout. The `QBT_WEBUI_PORT` env and existing config are untouched.

Related: #1352 fixes the underlying reason this group stayed invisible on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)