### PR TITLE
fix(renovate): replace removed matchPackagePatterns with matchPackageNames

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -1,32 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    // Critical Infrastructure - No automerge
-    {
-      "description": "Critical infrastructure - manual approval required",
-      "matchPackagePatterns": [
-        "fluxcd/flux2",
-        "fluxcd/.*-controller",
-        "rook/rook",
-        "rook/ceph",
-        "cilium/cilium",
-        "cert-manager/cert-manager",
-        "external-secrets/external-secrets",
-        "1password/connect",
-        "kubernetes-sigs/external-dns",
-        "ingress-nginx/controller"
-      ],
-      "automerge": false,
-      "minimumReleaseAge": "7 days"
-    },
 
+  // NOTE: matchPackagePatterns was REMOVED in Renovate v40 (we run 44.x). It is
+  // not migrated — Renovate logs "No config migration necessary" and simply
+  // ignores the key. A rule whose only matcher is unrecognised has no
+  // constraints, so it matched EVERY package; last-wins precedence then let the
+  // permissive rules override "critical infrastructure", and rook-ceph /
+  // cert-manager PRs came out as "Automerge: Enabled".
+  //
+  // All matchers below use matchPackageNames. A value wrapped in /.../ is a
+  // regex (unanchored unless you anchor it); anything else is an exact name.
+  //
+  // Ordering matters: rules apply in order and later rules win. The
+  // critical-infrastructure rule is deliberately LAST so nothing can re-enable
+  // automerge for it. That matters because ghcr.io/home-operations/ holds both
+  // media apps (sonarr, plex, ...) and infra chart mirrors
+  // (charts-mirror/cilium, charts-mirror/external-dns).
+  "packageRules": [
     // Data/Storage - Automerge patches only
     {
       "description": "Data and storage services - patches only",
-      "matchPackagePatterns": [
-        "cloudnative-pg/postgres-operator",
-        "emqx/emqx",
-        "dragonflydb/dragonfly"
+      "matchPackageNames": [
+        "/^ghcr\\.io/dragonflydb/",
+        "/^docker\\.io/library/(postgres|mariadb)$/",
+        "/^docker\\.io/valkey/valkey$/",
       ],
       "matchUpdateTypes": ["patch"],
       "automerge": true,
@@ -35,14 +32,17 @@
       "minimumReleaseAge": "5 days"
     },
 
-    // Media apps - Fast automerge
+    // Media apps - Fast automerge.
+    // [^/]+$ deliberately matches only single-segment paths, so
+    // ghcr.io/home-operations/sonarr matches but
+    // ghcr.io/home-operations/charts-mirror/cilium does not.
     {
       "description": "Media applications - fast updates",
-      "matchPackagePatterns": [
-        "ghcr.io/onedr0p/.*",
-        "ghcr.io/home-operations/.*",
-        "jellyfin/jellyfin",
-        "wizarrrr/wizarr"
+      "matchPackageNames": [
+        "/^ghcr\\.io/home-operations/[^/]+$/",
+        "/^ghcr\\.io/onedr0p/[^/]+$/",
+        "/jellyfin/jellyfin$/",
+        "/wizarrrr/wizarr$/",
       ],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -53,18 +53,14 @@
     // Utility packages - Safe minor updates
     {
       "description": "Utility packages - minor and patch updates",
-      "matchPackagePatterns": [
-        "stakater/reloader",
-        "reloader",
-        "kured",
-        "node-feature-discovery",
-        "metrics-server",
-        "prometheus-operator/prometheus-config-reloader",
-        "grafana/.*",
-        "descheduler",
-        "system-upgrade-controller",
-        "volsync/volsync",
-        "mozilla/sops"
+      "matchPackageNames": [
+        "/reloader$/",
+        "/node-feature-discovery$/",
+        "/^ghcr\\.io/grafana/helm-charts/",
+        "/charts-mirror/(metrics-server|descheduler|volsync|alloy|intel-device-plugins-.*)$/",
+        "/kured$/",
+        "/system-upgrade-controller$/",
+        "/mozilla/sops$/",
       ],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -120,6 +116,24 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "dependencyDashboardApproval": true
+    },
+
+    // Critical Infrastructure - No automerge.
+    // LAST on purpose: this must override every rule above it.
+    {
+      "description": "Critical infrastructure - manual approval required",
+      "matchPackageNames": [
+        "/^ghcr\\.io/rook/",
+        "/charts-mirror/cilium$/",
+        "/cert-manager$/",
+        "/external-secrets$/",
+        "/flux-(instance|operator)$/",
+        "/^fluxcd/flux2$/",
+        "/charts-mirror/external-dns$/",
+        "/^docker\\.io/1password/",
+      ],
+      "automerge": false,
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## The bug

`matchPackagePatterns` was **removed in Renovate v40**. We run **44.8.0**. It isn't migrated — the run log says `No config migration necessary` — it's simply ignored.

A packageRule whose only matcher is unrecognised has **no constraints**, so it matches every package. All four rules keyed on `matchPackagePatterns` were affected, and last-wins precedence let the permissive media/utility rules override critical infrastructure.

This was live on real PRs:

```
PR #1372  rook-ceph v1.18.4 → v1.18.11   🚦 Automerge: Enabled.
PR #1355  cert-manager (patch)           🚦 Automerge: Enabled.
```

Both are supposed to be `automerge: false`. Nothing actually merged only because `allow_auto_merge` is `false` on the repo and Renovate's `renovate/stability-days` status was pending — accidental protection, not the config doing its job.

## Why a mechanical translation wasn't enough

Most of the old patterns never matched the real package names in the first place:

| old pattern | actual package | matched |
|---|---|---|
| `fluxcd/flux2` | `ghcr.io/controlplaneio-fluxcd/charts/flux-{instance,operator}` | no |
| `cilium/cilium` | `ghcr.io/home-operations/charts-mirror/cilium` | no |
| `cert-manager/cert-manager` | `quay.io/jetstack/charts/cert-manager` | no |
| `external-secrets/external-secrets` | `ghcr.io/external-secrets/charts/external-secrets` | no |
| `kubernetes-sigs/external-dns` | `ghcr.io/home-operations/charts-mirror/external-dns` | no |
| `rook/rook` | `ghcr.io/rook/rook-ceph{,-cluster}` | yes |
| `1password/connect` | `docker.io/1password/connect-{api,sync}` | yes |

Patterns are now written against the names Renovate actually sees.

## Two structural changes

**Critical infrastructure moves LAST.** `ghcr.io/home-operations/` contains both media apps *and* infra chart mirrors, so scoping alone can't keep them apart. Putting the restrictive rule last means nothing can re-enable automerge for it.

**The media rule anchors on `[^/]+$`** — single-segment paths only, so `home-operations/sonarr` matches but `home-operations/charts-mirror/cilium` doesn't.

## Dropped dead references

`cloudnative-pg` and `emqx` aren't deployed (only a stray secret key mentions CNPG), and `ingress-nginx` was removed from the cluster.

## Verification

Resolved every rule against the 102 package names extracted from `kubernetes/`, simulating regex matching and last-wins precedence:

```
=== CRITICAL INFRA (must be automerge=False) ===
  OK    ghcr.io/rook/rook-ceph                             -> False
  OK    ghcr.io/rook/rook-ceph-cluster                     -> False
  OK    ghcr.io/home-operations/charts-mirror/cilium       -> False
  OK    quay.io/jetstack/charts/cert-manager               -> False
  OK    ghcr.io/external-secrets/charts/external-secrets   -> False
  OK    ghcr.io/controlplaneio-fluxcd/charts/flux-instance -> False
  OK    ghcr.io/controlplaneio-fluxcd/charts/flux-operator -> False
  OK    ghcr.io/home-operations/charts-mirror/external-dns -> False
  OK    docker.io/1password/connect-api                    -> False

=== MEDIA (expect automerge=True) ===
  OK    ghcr.io/home-operations/sonarr                     -> True
  OK    ghcr.io/home-operations/plex                       -> True
  OK    ghcr.io/home-operations/qbittorrent                -> True

critical failures: 0
```

The critical rule catches exactly 11 packages with no over-matching — `ghcr.io/kashalls/external-dns-unifi-webhook` is correctly excluded.

## After merge

Confirm #1372 (rook-ceph) and #1355 (cert-manager) flip to **`Automerge: Disabled by config`** on the next hourly Renovate run. That's the proof this worked.

`allow_auto_merge` is still `false` at the repo level, so nothing automerges regardless — that's a separate decision, and this PR is the prerequisite for making it safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)