### PR TITLE
fix(renovate): count passing internal checks toward branch status

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,13 @@
   // (rook/cilium/cert-manager/external-secrets/flux) is automerge:false anyway,
   // so those still require a human to merge.
   internalChecksFilter: 'none',
+  // A *passing* internal check is not counted toward branch status by default,
+  // so renovate/stability-days sits PENDING forever rather than turning green —
+  // PRs #1302 (2026-06-30) and #1304 (2026-07-02) were still pending weeks after
+  // any window had elapsed. Combined with ignoreTests:false below (Renovate
+  // requires a green branch before automerging) that means automerge could never
+  // fire at all, not merely that it was delayed.
+  internalChecksAsSuccess: true,
   prConcurrentLimit: 30,
   prHourlyLimit: 0,
   branchConcurrentLimit: 30,


### PR DESCRIPTION
## The problem

`renovate/stability-days` doesn't just *look* like it's still running — it **never resolves**.

| PR | created | stability-days |
|---|---|---|
| #1302 | 2026-06-30 | `PENDING` |
| #1304 | 2026-07-02 | `PENDING` |

Both are over a month old. Any 3-day or 7-day window elapsed weeks ago.

That's the documented default:

> **`internalChecksAsSuccess`** (default `false`) — Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.

A *passing* internal check isn't counted toward branch status, so it sits neutral forever rather than going green.

## Why this matters beyond cosmetics

`renovate.json5` also sets `ignoreTests: false`, which makes Renovate require a green branch before automerging.

Branch never green → **automerge could never fire at all.** Not delayed — never.

This was the third of three independent blockers, and the only one that wasn't visible until the other two were cleared:

1. `allow_auto_merge: false` on the repo — platform automerge can't arm
2. `matchPackagePatterns` removed in Renovate v40 — fixed in #1382
3. **this** — branch status never goes green

Fixing 1 and 2 alone would still have produced zero automerges, with no obvious reason why.

## The change

```json5
internalChecksAsSuccess: true,
```

Satisfied internal checks now count toward branch status. The check turns green once the window elapses instead of hanging yellow, which both removes the noise from every Renovate PR and makes automerge structurally possible.

`minimumReleaseAge: '3 days'` and the per-rule overrides (1/5/7 days) are unchanged — the delay still applies, it just resolves now.

## Verification

Watch a **normal version update** PR after the next hourly run and confirm `renovate/stability-days` goes green once its window passes.

Deliberately not a digest-only PR: #1302 and #1304 are digest bumps (`be1ef4f → efb4959`), and digests carry no release timestamp — the same resolution problem behind gatus and tautulli in #1352. Those may stay pending for that separate reason, so they're a bad test case.

## Still not enabled

`allow_auto_merge` remains `false` at the repo level, so nothing automerges yet. With this and #1382 in, that becomes a safe switch to flip rather than a risky one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)