### PR TITLE
fix(renovate): drop minimumReleaseAge — it never passed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,28 +23,30 @@
     'prIgnoreNotification',
   ],
   rebaseWhen: 'behind-base-branch',
-  // NOTE: minimumReleaseAge needs a release timestamp. For datasource=docker that
-  // means walking the OCI index -> child manifest -> config blob for `created`.
-  // Multi-arch ghcr.io images that also publish unknown/unknown attestation
-  // manifests (gatus, tautulli, unpoller, ...) don't resolve reliably, so the age
-  // check could never pass and those updates sat in the dashboard's "Pending
-  // Status Checks" section forever. 'none' stops internal checks from filtering
-  // updates: PRs get created and CI + the automerge rules become the gate.
-  // Stability delays still apply to automerge decisions, and critical infra
-  // (rook/cilium/cert-manager/external-secrets/flux) is automerge:false anyway,
-  // so those still require a human to merge.
+  // NOTE: minimumReleaseAge was removed because it never worked here. It needs a
+  // release timestamp, and for our datasources Renovate can't get one: Helm OCI
+  // artifacts publish a application/vnd.cncf.helm.config.v1+json config (no
+  // `created`), and multi-arch ghcr.io images add unknown/unknown attestation
+  // manifests. With no timestamp the check does not fail loudly — it reports
+  // "Updates have not met minimum release age requirement" forever.
+  //
+  // Measured on run 30839924395: 44/44 branches pending, including the reloader
+  // chart 2.2.14 (created 2026-07-01, 33 days old), gatus v5.36.0 (76 days) and
+  // tautulli v2.17.2 (48 days). That made branch status yellow everywhere, which
+  // with ignoreTests:false gave mergeStatus="no automerge" on all 30 PRs. It was
+  // an unconditional block dressed up as a 3 day delay.
+  //
+  // What still gates a merge: "Validate Success" is a required check, critical
+  // infrastructure is automerge:false in renovate/autoMerge.json5, and majors
+  // need dependencyDashboardApproval.
+  //
+  // The two settings below are inert without an internal check to act on. They
+  // are kept because they are the correct values if an age gate is ever restored.
   internalChecksFilter: 'none',
-  // A *passing* internal check is not counted toward branch status by default,
-  // so renovate/stability-days sits PENDING forever rather than turning green —
-  // PRs #1302 (2026-06-30) and #1304 (2026-07-02) were still pending weeks after
-  // any window had elapsed. Combined with ignoreTests:false below (Renovate
-  // requires a green branch before automerging) that means automerge could never
-  // fire at all, not merely that it was delayed.
   internalChecksAsSuccess: true,
   prConcurrentLimit: 30,
   prHourlyLimit: 0,
   branchConcurrentLimit: 30,
-  minimumReleaseAge: '3 days',
   rollbackPrs: true,
   ignoreTests: false,
   recreateWhen: 'always',

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -28,8 +28,7 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
-      "minimumReleaseAge": "5 days"
+      "platformAutomerge": true
     },
 
     // Media apps - Fast automerge.
@@ -46,8 +45,7 @@
       ],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "automergeType": "branch",
-      "minimumReleaseAge": "1 day"
+      "automergeType": "branch"
     },
 
     // Utility packages - Safe minor updates
@@ -65,8 +63,7 @@
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
-      "minimumReleaseAge": "3 days"
+      "platformAutomerge": true
     },
 
     // GitHub Actions - Always automerge
@@ -106,8 +103,7 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
-      "ignoreTests": false,
-      "minimumReleaseAge": "3 days"
+      "ignoreTests": false
     },
 
     // Major updates need approval
@@ -132,8 +128,7 @@
         "/charts-mirror/external-dns$/",
         "/^docker\\.io/1password/",
       ],
-      "automerge": false,
-      "minimumReleaseAge": "7 days"
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## The finding

`minimumReleaseAge` needs a release timestamp, and Renovate can't get one for our datasources:

- **Helm OCI artifacts** publish `application/vnd.cncf.helm.config.v1+json` — no `created` field
- **Multi-arch ghcr.io images** add `unknown/unknown` attestation manifests to the index

With no timestamp the check doesn't fail loudly. It reports *"Updates have not met minimum release age requirement"* indefinitely.

Measured on run [30839924395](https://github.com/sob/home-ops/actions/runs/30839924395): **44 of 44 branches pending — 100%** — including packages far past any window:

| package | created / released | age |
|---|---|---|
| reloader chart 2.2.14 | 2026-07-01 | 33 days |
| gatus v5.36.0 | 2026-05-19 | 76 days |
| tautulli v2.17.2 | 2026-06-16 | 48 days |

The chain:

```
age never met  ->  "Branch status yellow" on all 44 branches
               ->  ignoreTests:false requires green
               ->  mergeStatus="no automerge" on all 30 PRs
```

So this was never a 3-day delay. It was an **unconditional block presented as one** — and the same root cause as the invisible dashboard backlog. Making the PRs visible surfaced the problem; it didn't resolve it.

## What this supersedes

`internalChecksAsSuccess: true` did not help. That setting only applies to internal checks that **pass**, and none of these ever do. The status was created at 17:52:33 — after that change was live — and still read pending. Left in place as inert-but-correct.

## The change

Removes the global `'3 days'` and the per-rule 1/3/5/7-day overrides. `internalChecksFilter` and `internalChecksAsSuccess` stay — inert without an internal check to act on, but the right values if an age gate is ever restored on a datasource that does report timestamps.

## What still gates a merge

- **`Validate Success` is a required check** — kustomize, kubeconform, flux-local and OPA run on every PR touching `kubernetes/`
- **Critical infrastructure is `automerge: false`** — confirmed working in run 30839924395, which logged `PR is not configured for automerge` for exactly the 8 expected branches: `patch-rook-ceph`, `patch-cert-manager`, `cert-manager`, `charts-mirror-cilium`, `charts-mirror-external-dns`, `flux-instance-all`, `flux-operator-all`, `external-secrets-all`
- **Majors need `dependencyDashboardApproval`**

## Expect a large batch

Once this merges and Renovate runs, roughly 26 non-critical PRs become eligible and will merge in quick succession — `renovate/stability-days` was the only thing holding them. Flux will then reconcile all of them.

The backlog spans months of versions (jellyfin 10.10.7→10.11.11, zigbee2mqtt 2.5.1→2.13.0, homarr 1.30.1→1.73.0), so this is a large simultaneous change. That is the intended outcome here, but worth watching `flux get hr -A` while it settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)