### PR TITLE
fix(recyclarr): apply LQ custom format to the Any quality profile

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -253,3 +253,23 @@ radarr:
           - name: HD - 720p/1080p
           - name: Ultra-HD
             score: 0
+      # LQ catches low-quality release groups — YTS/YIFY, OFT, WiKi, FGT, AOC,
+      # RARBG, GalaxyRG and ~90 others. It was only ever scored on
+      # HD - 720p/1080p and Ultra-HD, which between them hold 25 of ~1166 movies.
+      # The other 1141 sit on the Any profile, where every custom format scored 0
+      # — so nothing penalised an LQ release there. That is how Twisters was
+      # imported as YTS.MX at 5.9GB while a 23GB DV release existed.
+      #
+      # Scope note: this assigns LQ only. Adding the blocks above to Any would
+      # apply audio, movie-version and release-group scoring across all 1141
+      # movies, which is a much larger behaviour change than blocking junk groups.
+      #
+      # This blocks FUTURE grabs only. The Any profile has upgradeAllowed=false,
+      # so Radarr will not replace the 27 existing LQ-group files (489GB) already
+      # in the library — min_format_score: 0 simply rejects new releases scoring
+      # negative. Replacing what is already there needs upgrades enabled on Any
+      # and is a separate decision.
+      - trash_ids:
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+        quality_profiles:
+          - name: Any


### PR DESCRIPTION
## The gap

The `LQ` custom format already matches YTS — `^(YTS(.(MX|LT|AG))?)$` and `^(YIFY)$` — plus ~90 other low-quality groups. The problem was never the format, it was **where the score got applied**.

Recyclarr assigns custom format scores only to the profiles listed under `quality_profiles`. Ours listed `HD - 720p/1080p` and `Ultra-HD`:

| profile | movies | LQ score |
|---|---|---|
| **Any** | **1,141** | **0 — no penalty** |
| Ultra-HD | 25 | −10000 |

So the penalty covered 2% of the library. On `Any`, every custom format scored 0 and nothing blocked a junk release.

That's how **Twisters** was imported as `YTS.MX` at **5.9 GB** while a 23 GB WEBDL-2160p DV release sat unimported in the download folder.

## Current exposure

A scan of the library against LQ's group list found **27 files, 489 GB, all on `Any`**:

```
OFT      6      chd  2
WiKi     4      BdC  1     PRoDJi 1
FGT      4      HDT  1     wiki   1
AOC      3      iVy  1     4K4U   1   GHD 1
```

## The change

Adds one block assigning `LQ` to the `Any` profile.

**Deliberately scoped to LQ only.** Adding the existing blocks to `Any` would apply audio, movie-version and release-group scoring across all 1141 movies — a far larger behaviour change than blocking junk groups.

## What this does and does not do

**Does:** blocks future LQ grabs. The `Any` profile has `minFormatScore: 0`, so a release scoring −10000 is rejected outright.

**Does not:** replace the 27 files already in the library. I verified `Any` has:

```
upgradeAllowed=false  minFormatScore=0  cutoffFormatScore=0
```

With `upgradeAllowed=false` Radarr will not upgrade in place regardless of custom format scores. Retroactively replacing those 489 GB needs upgrades enabled on `Any`, which is a separate decision — it would make Radarr start hunting upgrades across the whole 1141-movie profile, not just the LQ files.

I'd suggest landing this first (zero blast radius, stops the bleeding) and treating the retroactive cleanup as its own change.

## Validation

`task validate` passes — kustomize build, kubeconform, flux-local, and OPA policies all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)