### PR TITLE
fix(ci): restore container builds, add bc and python3 to the ARC runner

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -192,7 +192,12 @@ jobs:
         id: build
         uses: docker/bake-action@v7
         with:
-          workdir: containers/${{ matrix.app }}
+          # `source`, not `workdir`: bake-action v6 dropped `workdir` and #1453
+          # took this from v5 to v7, so the input was silently ignored and bake
+          # ran from the repo root — "lstat ./docker-bake.hcl: no such file or
+          # directory" for every container. Relative paths (the `files:` entry
+          # below) resolve from `source`, so this is a straight rename.
+          source: ./containers/${{ matrix.app }}
           targets: ${{ matrix.app }}
           provenance: false
           set: |
@@ -489,7 +494,7 @@ jobs:
           bake_output=$(docker buildx bake --print)
           target=$(echo "$bake_output" | jq -r '.target | keys[0]')
           has_rolling=$(echo "$bake_output" | jq -r ".target[\"${target}\"].tags[]" | grep -c "rolling" || echo "0")
-          
+
           if [ "$has_rolling" -gt "0" ]; then
             echo "App ${{ matrix.app }} uses rolling tag - triggering Flux reconciliation..."
             if [ -n "$FLUX_WEBHOOK_URL" ]; then

--- a/containers/arc-runner/Dockerfile
+++ b/containers/arc-runner/Dockerfile
@@ -21,12 +21,28 @@ ENV ANDROID_HOME=/opt/android-sdk
 ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
 ENV PATH="${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools"
 
+# bc and python3 are here for the same reason gh is installed below: every
+# GitHub-hosted ubuntu-* image ships them, the actions-runner base image does
+# not, and jobs that moved onto this pool assume them. Each absence shows up as
+# a bare exit 127 in an unrelated-looking step:
+#   bc      doorgames-io/blockhead's nightly "Update Coverage Badges"
+#   python3 the same repo pins actions/setup-python in five workflows to
+#           work around it; with python3 here those pins become optional
+# Ubuntu noble's python3 is 3.12, which is what those pins ask for.
+#
+# The base already provides curl, jq, git, sed, awk, timeout and (via
+# build-essential -> dpkg-dev -> perl) shasum, so this list is the whole gap
+# for the commands blockhead's arc-linux jobs actually invoke.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    bc \
     build-essential \
     openjdk-17-jdk-headless \
+    python3 \
     unzip \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && bc --version | head -1 \
+    && python3 --version
 
 ARG TARGETARCH
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}


### PR DESCRIPTION
Two commits. The second is a prerequisite — container builds have been broken repo-wide since yesterday, so the first couldn't be validated without it.

---

## 1. Container builds are broken repo-wide (`bake-action` v5 → v7)

`#1453` took `docker/bake-action` from v5.13.0 to v7.3.0. **v6 removed the `workdir` input** in favour of `source`, so the value was silently ignored, bake ran from the repo root, and every container build died:

```
ERROR: failed to solve: lstat ./docker-bake.hcl: no such file or directory
```

Last green containers run was 2026-08-03 18:27Z. The bump merged 2026-08-04 15:09Z, and nothing built after it until this branch — so this affects `enigma-bbs`, `mysticbbs` and `text0wnz` too, not just `arc-runner`.

A straight rename is enough: per the [v7 README](https://github.com/docker/bake-action/tree/v7.3.0#source), relative paths resolve from `source`, so the existing `files: ./docker-bake.hcl` keeps working.

> Worth noting `#1453` was a `!`-flagged major bump. `renovate.json` sets `automerge: false` + `needs-review` for majors, so the gate worked — the breaking change just wasn't caught in review.

## 2. `bc` and `python3` — third instance of the #1343 gap

GitHub-hosted `ubuntu-*` images ship these; the `actions-runner` base image doesn't. Each absence surfaces as a bare **exit 127** in a step that looks unrelated.

**`bc`** — `doorgames-io/blockhead`'s nightly `Update Coverage Badges` still fails on the post-#1343 image:

```
.../96f0435a….sh: line 13: bc: command not found
##[error]Process completed with exit code 127.
```

**`python3`** — the gap that repo already works around by pinning `actions/setup-python` in five workflows. One says so outright: *"the arc-linux image ships no interpreter (the same gap that broke CodeQL's node dependency)"*. Noble ships 3.12, exactly what those pins request, so they become optional rather than load-bearing.

### Why only these two

Rather than fix one binary and wait for the next, I listed every command blockhead's `arc-linux` jobs invoke and subtracted what the image has:

| Command | Status |
|---|---|
| `curl` `jq` `git` `unzip` | base image |
| `sed` `awk` `timeout` `tar` `base64` | coreutils/mawk |
| `shasum` | `build-essential` → `dpkg-dev` → `perl` |
| `node` `npm` | `actions/setup-node` |
| `gh` | #1343 |
| **`bc`** **`python3`** | **missing — this PR** |

## Verification

Build green on both architectures ([run 30954313676](https://github.com/sob/home-ops/actions/runs/30954313676)), with all three asserted in-layer so a regression fails the build rather than a job:

```
bc 1.07.1
Python 3.12.3
gh version 2.96.0
```

## After merge

Digest bump, as in #1344:

```
docker buildx imagetools inspect ghcr.io/sob/arc-runner:rolling --format '{{json .}}' | jq -r '.manifest.digest'
```