### PR TITLE
fix(rook-ceph): revert charts to v1.18.4 to restore CSI

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.3
+    tag: v1.18.4
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.3
+    tag: v1.18.4
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
## Impact

**ceph-csi node plugins have been down ~7.5 hours.** Anything trying to *mount* a ceph PVC is blocked; already-running pods are unaffected, which is why the cluster otherwise looks healthy.

```
csi-rbdplugin       desired=8  ready=0
csi-cephfsplugin    desired=8  ready=0
```

12 pods stuck: jellyseerr, qui, wizarr, homarr, grafana, mosquitto, enigma-bbs, plus three volsync backup jobs (plex, recyclarr, romm).

It also blocks unrelated deploys via the dependency chain `sabnzbd → volsync → rook-ceph-cluster` — which is why #1462 merged but never rolled out.

## Root cause

The operator **image** is hardcoded at `kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml:210`:

```yaml
    image:
      tag: v1.16.0-4.g6da8ef89d
```

#1422 bumped the **chart** 1.18.4 → 1.20.3, leaving a v1.16 operator managing CSI RBAC for the 1.20.3 chart's newer ceph-csi images:

```
F0804 driver.go:146] failed to get node "metal-01" information: Unauthorized
```

That pin traces to `15b1b8ea` (2024-12-29), commented *"work around until 1.16.1 is released"*. 1.16.1 shipped ~20 months ago. It was never removed, so Renovate has been advancing the chart around a frozen image ever since.

## Data is not at risk

`CephCluster` is `Ready`, 8 OSDs up, `HEALTH_WARN` is only `RECENT_CRASH` (1 daemon). This is the CSI/mount layer only.

**Ceph itself never started upgrading:**

```
3 quay.io/ceph/ceph:v19.2.3   (mon)
4 quay.io/ceph/ceph:v19.2.3   (osd)
```

The 1.20.3 chart wanted `v20.2.2` — a **major Ceph jump (19→20) nobody explicitly chose**, since `cephVersion` isn't set anywhere in this repo and comes from chart defaults. Because the v1.16 operator couldn't drive it, the data plane never moved. There is no half-finished Ceph upgrade to unwind — that's the part that would have been genuinely dangerous.

## This change

Reverts both charts to **v1.18.4**, the last combination known good with the pinned v1.16.0 image. Also returns the implicit `cephVersion` to 19.x, matching what's actually running.

**Deliberately does not touch the image pin.** This PR is only about restoring service; removing the pin has its own blast radius and is a separate follow-up.

## After merge — needs a forced reconcile

`rook-ceph-cluster` is `Stalled` with `MissingRollbackTarget` after exhausting retries, so Flux won't self-heal:

```
rev 16  14:18  failed    1.20.3
rev 17  14:48  deployed  1.18.4   <- Flux rolled back
rev 18  14:50  failed    1.20.3   <- then retried
rev 19  15:04  failed    1.20.3
rev 20  15:05  failed    1.20.3   <- retries exhausted
```

```bash
flux reconcile hr rook-ceph-cluster -n rook-ceph --force
```

Then watch `csi-rbdplugin` / `csi-cephfsplugin` reach ready and the 12 stuck pods mount.

## Follow-ups (separate PRs, each verified healthy first)

1. **Pin `cephVersion` explicitly** — do this before any Rook bump, so chart upgrades stop silently carrying Ceph daemon versions
2. **Remove the stale v1.16.0 image pin** on 1.18.4, verify CSI healthy
3. **1.18 → 1.19 → 1.20, one minor at a time** — Rook only supports single-minor upgrades; operator first, then cluster
4. **Ceph 19 → 20 separately**, once Rook is on 1.20 and stable

Also worth a Renovate rule so rook-ceph only ever offers single-minor bumps. `automerge: false` correctly stopped this merging unattended, but it didn't stop a two-minor jump being presented as one tidy PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)