### PR TITLE
fix(rook-ceph): pin cephVersion explicitly

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -82,6 +82,17 @@ spec:
       mon_max_pg_per_osd = 300
 
     cephClusterSpec:
+      # Pin the Ceph daemon version explicitly. Without this it comes from the
+      # chart default, so a Rook chart bump silently carries a Ceph version with
+      # it — chart 1.20.3 defaulted to v20.2.2 and would have started a major
+      # Ceph 19 -> 20 upgrade that nobody chose. Chart v1.18.4 defaults to
+      # v19.2.3, which is what every mon and OSD is already running, so setting
+      # this is a no-op today and purely stops future drift.
+      #
+      # Ceph upgrades are now an explicit edit here, never a side effect of a
+      # Rook bump, and must be done separately from a Rook version change.
+      cephVersion:
+        image: quay.io/ceph/ceph:v19.2.3
       # Resource definitions
       resources:
         osd:


### PR DESCRIPTION
**Step 2 of 4.** Depends on #1467 being merged and CSI verified healthy first.

## Why

`cephVersion` isn't set anywhere in this repo, so the Ceph daemon image comes from the Rook chart default. **A Rook chart bump therefore silently carries a Ceph version with it.**

Chart 1.20.3 defaults to `quay.io/ceph/ceph:v20.2.2`, so #1422 would have started a **major Ceph 19 → 20 upgrade that nobody chose**. It only avoided happening because the pinned v1.16.0 operator couldn't drive it — mons and OSDs stayed on v19.2.3.

That's the most dangerous part of this incident, and it was pure luck.

## This change is a no-op today

Verified with `helm show values oci://ghcr.io/rook/rook-ceph-cluster --version v1.18.4`:

```yaml
  cephVersion:
    image: quay.io/ceph/ceph:v19.2.3
```

And what's actually running:

```
3 quay.io/ceph/ceph:v19.2.3   (mon)
4 quay.io/ceph/ceph:v19.2.3   (osd)
```

Identical. Setting it explicitly changes nothing against the live cluster — it purely stops future drift.

## Effect

Ceph upgrades become an explicit edit to this field rather than a side effect of a Rook bump, and must be done separately from a Rook version change.

This is the prerequisite that makes steps 3 and 4 safe: without it, walking Rook 1.18 → 1.19 → 1.20 would drag Ceph along at each hop.

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)