### PR TITLE
fix(rook-ceph): remove stale v1.16.0 operator image pin

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -206,8 +206,13 @@ spec:
       enabled: true
     monitoring:
       enabled: true
-    image:
-      tag: v1.16.0-4.g6da8ef89d
+    # NOTE: image.tag was pinned to v1.16.0-4.g6da8ef89d in 15b1b8ea
+    # (2024-12-29), commented "work around until 1.16.1 is released". 1.16.1
+    # shipped long ago but the pin was never removed, so Renovate kept advancing
+    # the chart around a frozen operator image. By the time the chart reached
+    # 1.20.3 a v1.16 operator was managing CSI RBAC for 1.20-era ceph-csi images
+    # and every node plugin died with "failed to get node ... : Unauthorized".
+    # Leave this unset so the operator image always matches its chart.
     tolerations:
       - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"


### PR DESCRIPTION
**Step 3 of 4.** Depends on #1467 and #1468 being merged and verified healthy first.

## The pin was a temporary workaround that outlived its reason

Introduced in `15b1b8ea` (2024-12-29):

```yaml
    image:
      tag: v1.16.0-4.g6da8ef89d
```

Commit message: *"[rook-ceph] work around until 1.16.1 is released"*. 1.16.1 shipped long ago; the pin was never removed.

Renovate kept advancing the **chart** around a **frozen image**. By the time the chart reached 1.20.3 in #1422, a v1.16 operator was managing CSI RBAC for 1.20-era ceph-csi images, and every node plugin died on startup:

```
failed to get node "metal-01" information: Unauthorized
```

That's the root cause of the ~7.5h CSI outage. This PR removes the class of bug, not just the instance.

## Effect

Verified with `helm show values oci://ghcr.io/rook/rook-ceph --version v1.18.4`:

```yaml
image:
  repository: docker.io/rook/ceph
  tag: v1.18.4
```

So on 1.18.4 the operator goes **v1.16.0 → v1.18.4**, matching the chart that's already deployed.

**Unlike #1468, this is not a no-op.** Expect the operator pod to roll and CSI daemonsets to be re-reconciled. Ceph daemons are unaffected — `cephVersion` is pinned to v19.2.3 by #1468, which is exactly why that one lands first.

## Ordering matters

Removing this pin while the chart is still on 1.20.3 would jump the operator **v1.16 → v1.20 in one step**, which Rook doesn't support. The revert has to land first.

## Verify after merge

```bash
kubectl get deploy -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}'
# expect docker.io/rook/ceph:v1.18.4

kubectl get ds -n rook-ceph | grep csi-
# expect ready == desired
```

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)