### PR TITLE
feat(rook-ceph): upgrade to v1.19.8

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.18.11
+    tag: v1.19.8
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.18.11
+    tag: v1.19.8
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
**DRAFT — step 4a of 4. Blocked until #1467, #1468 and #1469 are merged and verified healthy.**

Deliberately a draft so it can't be merged out of sequence. That's the failure mode that caused this incident.

## Why two hops

Rook supports **single-minor upgrades only**. #1422 tried 1.18.4 → 1.20.3 in one step, which couldn't work even with a matching operator image. The path back to 1.20 is:

```
1.18.4  ->  1.18.11   (patch — Renovate will offer this automatically)
1.18.11 ->  1.19.8    <- this PR
1.19.8  ->  1.20.3    <- next PR
```

## What this does

With the image pin removed by #1469, the operator image tracks the chart automatically, so operator and CSI move to v1.19.8 together.

`cephVersion` stays pinned at v19.2.3 by #1468, so **no Ceph daemon upgrade rides along** — that's step 4b, separately.

## Before marking ready

```bash
kubectl get ds -n rook-ceph | grep csi-              # ready == desired
kubectl get cephcluster -n rook-ceph                 # Ready / HEALTH_OK
kubectl get deploy -n rook-ceph rook-ceph-operator \
  -o jsonpath='{.spec.template.spec.containers[0].image}'   # v1.18.x
```

Ideally take the 1.18.11 patch first so you're on the latest 1.18 before the minor hop.

## After merge

Watch the operator roll, then CSI daemonsets re-reconcile, then confirm `CephCluster` returns to Ready before touching #1470.

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)