### PR TITLE
feat(rook-ceph): upgrade to v1.20.3

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.8
+    tag: v1.20.3
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.8
+    tag: v1.20.3
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
**DRAFT — step 4b of 4. Stacked on #1470; blocked until that is merged and verified healthy.**

Based on `feat/rook-ceph-119` rather than `main`, so the diff shows the actual hop (1.19.8 → 1.20.3). Retarget to `main` once #1470 lands.

## Completes the path

```
1.18.4  ->  1.18.11   patch
1.18.11 ->  1.19.8    #1470
1.19.8  ->  1.20.3    <- this PR
```

This is the same destination #1422 aimed for, reached one minor at a time instead of in a single unsupported jump.

## Ceph stays on 19

`cephVersion` is pinned to v19.2.3 by #1468. Without that pin, chart 1.20.3 would default to `quay.io/ceph/ceph:v20.2.2` and begin a **major Ceph 19 → 20 upgrade** — the silent drift that made #1422 dangerous.

Upgrading Ceph is a separate, explicit decision. See below.

## Before marking ready

```bash
kubectl get cephcluster -n rook-ceph              # Ready / HEALTH_OK
kubectl get ds -n rook-ceph | grep csi-           # ready == desired on 1.19.8
kubectl get deploy -n rook-ceph rook-ceph-operator \
  -o jsonpath='{.spec.template.spec.containers[0].image}'   # v1.19.8
```

## Step 4b — Ceph 19 → 20, afterwards

Intentionally **not** included here. Once Rook is stable on 1.20.3, it becomes a one-line change to `cephVersion` in `cluster/helmrelease.yaml`.

Do it on its own, never bundled with a Rook bump, and read the Ceph v20 release notes first — a major Ceph upgrade rewrites daemon state and is materially riskier than any Rook chart bump. Verify backups are current beforehand; volsync jobs have been failing during this outage.

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)