### PR TITLE
fix(flux): escape runtime variables for strict postBuild substitution

### DIFF
--- a/kubernetes/apps/default/bazarr/app/resources/subcleaner.sh
+++ b/kubernetes/apps/default/bazarr/app/resources/subcleaner.sh
@@ -12,7 +12,7 @@ if [[ -n "$section" ]]; then
     printf "Refreshing Plex section '%s' for '%s' ...\n" "$section" "$(dirname "$1")"
     /usr/bin/curl -I -X GET -G \
         --data-urlencode "path=$(dirname "$1")" \
-        --data-urlencode "X-Plex-Token=${PLEX_TOKEN}" \
+        --data-urlencode "X-Plex-Token=$${PLEX_TOKEN}" \
         --no-progress-meter \
-            "http://plex.default.svc.cluster.local:32400/library/sections/${section}/refresh"
+            "http://plex.default.svc.cluster.local:32400/library/sections/$${section}/refresh"
 fi

--- a/kubernetes/apps/default/cert-exporter/app/resources/export.sh
+++ b/kubernetes/apps/default/cert-exporter/app/resources/export.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 
 # Default and required environment variables
-ACMESH=${ACMESH:-/usr/local/bin/acme.sh}
-DEPLOY_HOOK=${DEPLOY_HOOK}
+ACMESH=$${ACMESH:-/usr/local/bin/acme.sh}
+DEPLOY_HOOK=$${DEPLOY_HOOK}
 
 # Check base required environment variables
 [ -z "$DOMAINS" ] && echo "Error: DOMAINS not set" && exit 1
@@ -15,42 +15,42 @@ DEPLOY_HOOK=${DEPLOY_HOOK}
 MAIN_DOMAIN=$(echo "$DOMAINS" | awk '{print $1}')
 
 # Build the domain parameters for acme.sh
-DOMAIN_PARAMS="-d ${MAIN_DOMAIN}"
+DOMAIN_PARAMS="-d $${MAIN_DOMAIN}"
 for domain in $(echo "$DOMAINS" | cut -d' ' -f2-); do
     DOMAIN_PARAMS="$DOMAIN_PARAMS -d $domain"
 done
 
 # Check hook-specific required variables
-case "${DEPLOY_HOOK}" in
+case "$${DEPLOY_HOOK}" in
     "synology_dsm")
         [ -z "$SYNO_HOSTNAME" ] && echo "Error: SYNO_HOSTNAME not set" && exit 1
         [ -z "$SYNO_USERNAME" ] && echo "Error: SYNO_USERNAME not set" && exit 1
         [ -z "$SYNO_PASSWORD" ] && echo "Error: SYNO_PASSWORD not set" && exit 1
-        export SYNO_USERNAME="${SYNO_USERNAME}"
-        export SYNO_PASSWORD="${SYNO_PASSWORD}"
-        export SYNO_CERTIFICATE="${MAIN_DOMAIN}"
-        export SYNO_SCHEME=${SYNO_SCHEME:-https}
-        export SYNO_PORT=${SYNO_PORT}
-        export SYNO_CREATE=${SYNO_CREATE:-1}
-        [ "${SYNO_SCHEME}" = "https" ] && export SYNO_Insecure="${SYNO_INSECURE:-1}"
+        export SYNO_USERNAME="$${SYNO_USERNAME}"
+        export SYNO_PASSWORD="$${SYNO_PASSWORD}"
+        export SYNO_CERTIFICATE="$${MAIN_DOMAIN}"
+        export SYNO_SCHEME=$${SYNO_SCHEME:-https}
+        export SYNO_PORT=$${SYNO_PORT}
+        export SYNO_CREATE=$${SYNO_CREATE:-1}
+        [ "$${SYNO_SCHEME}" = "https" ] && export SYNO_Insecure="$${SYNO_INSECURE:-1}"
         ;;
     "ssh")
         [ -z "$SSH_HOST" ] && echo "Error: SSH_HOST not set" && exit 1
         [ -z "$SSH_USER" ] && echo "Error: SSH_USER not set" && exit 1
-        export SSH_DEPLOY_USER="${SSH_USER}"
-        export SSH_DEPLOY_HOST="${SSH_HOST}"
+        export SSH_DEPLOY_USER="$${SSH_USER}"
+        export SSH_DEPLOY_HOST="$${SSH_HOST}"
         # Optional SSH parameters with their defaults
-        export SSH_DEPLOY_PORT="${SSH_PORT:-22}"
-        export SSH_DEPLOY_KEY="${SSH_KEY:-}"
-        export SSH_DEPLOY_REMOTE_CMD="${SSH_CMD:-}"
-        export SSH_DEPLOY_KEY_PASS="${SSH_KEY_PASS:-}"
+        export SSH_DEPLOY_PORT="$${SSH_PORT:-22}"
+        export SSH_DEPLOY_KEY="$${SSH_KEY:-}"
+        export SSH_DEPLOY_REMOTE_CMD="$${SSH_CMD:-}"
+        export SSH_DEPLOY_KEY_PASS="$${SSH_KEY_PASS:-}"
         # Target paths for certificate files
-        export SSH_DEPLOY_CERT_PATH="${SSH_CERT_PATH:-/etc/ssl/${MAIN_DOMAIN}.crt}"
-        export SSH_DEPLOY_KEY_PATH="${SSH_KEY_PATH:-/etc/ssl/${MAIN_DOMAIN}.key}"
-        export SSH_DEPLOY_CA_PATH="${SSH_CA_PATH:-/etc/ssl/${MAIN_DOMAIN}.ca}"
-        export SSH_DEPLOY_FULLCHAIN_PATH="${SSH_FULLCHAIN_PATH:-/etc/ssl/${MAIN_DOMAIN}.fullchain.cer}"
+        export SSH_DEPLOY_CERT_PATH="$${SSH_CERT_PATH:-/etc/ssl/$${MAIN_DOMAIN}.crt}"
+        export SSH_DEPLOY_KEY_PATH="$${SSH_KEY_PATH:-/etc/ssl/$${MAIN_DOMAIN}.key}"
+        export SSH_DEPLOY_CA_PATH="$${SSH_CA_PATH:-/etc/ssl/$${MAIN_DOMAIN}.ca}"
+        export SSH_DEPLOY_FULLCHAIN_PATH="$${SSH_FULLCHAIN_PATH:-/etc/ssl/$${MAIN_DOMAIN}.fullchain.cer}"
         # Optional reload command
-        export SSH_DEPLOY_RELOAD_CMD="${SSH_RELOAD_CMD:-}"
+        export SSH_DEPLOY_RELOAD_CMD="$${SSH_RELOAD_CMD:-}"
         ;;
     *)
         echo "Error: DEPLOY_HOOK must be either 'synology_dsm' or 'ssh'"
@@ -59,27 +59,27 @@ case "${DEPLOY_HOOK}" in
 esac
 
 # Check if certificate exists
-if ${ACMESH} --list | grep -q "${MAIN_DOMAIN}"; then
+if $${ACMESH} --list | grep -q "$${MAIN_DOMAIN}"; then
     # Get renewal date (last field, in format 2025-01-03T05:20:17Z)
-    cert_line=$(${ACMESH} --list | grep "${MAIN_DOMAIN}")
+    cert_line=$($${ACMESH} --list | grep "$${MAIN_DOMAIN}")
     renewal_date=$(echo "$cert_line" | awk '{print $(NF)}')
     now=$(date '+%Y-%m-%dT%H:%M:%SZ')
 
     # Convert dates to epoch
-    renew_time=$(date -d "${renewal_date}" +%s)
-    current_time=$(date -d "${now}" +%s)
+    renew_time=$(date -d "$${renewal_date}" +%s)
+    current_time=$(date -d "$${now}" +%s)
     days_remaining=$(( (renew_time - current_time) / 86400 ))
 
-    if [ "${days_remaining}" -gt 30 ] 2>/dev/null; then
-        echo "Certificate for ${MAIN_DOMAIN} exists with ${days_remaining} days remaining."
-        ${ACMESH} --deploy -d ${MAIN_DOMAIN} --deploy-hook "${DEPLOY_HOOK}" --insecure
+    if [ "$${days_remaining}" -gt 30 ] 2>/dev/null; then
+        echo "Certificate for $${MAIN_DOMAIN} exists with $${days_remaining} days remaining."
+        $${ACMESH} --deploy -d $${MAIN_DOMAIN} --deploy-hook "$${DEPLOY_HOOK}" --insecure
         exit $?
     else
-        echo "Certificate exists but only ${days_remaining} days remaining. Renewing..."
-        ${ACMESH} --renew ${DOMAIN_PARAMS} --force --server letsencrypt --dns dns_cf
+        echo "Certificate exists but only $${days_remaining} days remaining. Renewing..."
+        $${ACMESH} --renew $${DOMAIN_PARAMS} --force --server letsencrypt --dns dns_cf
         if [ $? -eq 0 ]; then
             echo "Certificate renewed successfully. Deploying..."
-            ${ACMESH} --deploy -d ${MAIN_DOMAIN} --deploy-hook "${DEPLOY_HOOK}" --insecure
+            $${ACMESH} --deploy -d $${MAIN_DOMAIN} --deploy-hook "$${DEPLOY_HOOK}" --insecure
             exit $?
         else
             echo "Failed to renew certificate"
@@ -89,12 +89,12 @@ if ${ACMESH} --list | grep -q "${MAIN_DOMAIN}"; then
 fi
 
 # Issue new certificate if it doesn't exist
-echo "Issuing new certificate for ${MAIN_DOMAIN}..."
-${ACMESH} --issue ${DOMAIN_PARAMS} --dns dns_cf --keylength 4096 --server letsencrypt
+echo "Issuing new certificate for $${MAIN_DOMAIN}..."
+$${ACMESH} --issue $${DOMAIN_PARAMS} --dns dns_cf --keylength 4096 --server letsencrypt
 
 if [ $? -eq 0 ]; then
     echo "Certificate issued successfully. Deploying..."
-    ${ACMESH} --deploy -d ${MAIN_DOMAIN} --deploy-hook "${DEPLOY_HOOK}"
+    $${ACMESH} --deploy -d $${MAIN_DOMAIN} --deploy-hook "$${DEPLOY_HOOK}"
     exit $?
 else
     echo "Failed to issue certificate"

--- a/kubernetes/apps/default/homarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homarr/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               repository: ghcr.io/homarr-labs/homarr
               tag: v1.73.0
             env:
-              TZ: ${TIMEZONE}
+              TZ: America/Chicago
               LOG_LEVEL: debug
             envFrom:
               - secretRef:

--- a/kubernetes/apps/default/homeassistant/ks.yaml
+++ b/kubernetes/apps/default/homeassistant/ks.yaml
@@ -30,6 +30,10 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: hass
+      # Used by HOME_ASSISTANT_TRUSTED_PROXIES. Was never defined anywhere, so
+      # under non-strict postBuild it silently rendered as an empty string and
+      # Home Assistant had no trusted proxies configured at all.
+      CLUSTER_POD_CIDR: 10.42.0.0/16
       VOLSYNC_SCHEDULE: "30 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_STORAGECLASS: ceph-block

--- a/kubernetes/apps/default/radarr/app/resources/pushover-notify.sh
+++ b/kubernetes/apps/default/radarr/app/resources/pushover-notify.sh
@@ -1,93 +1,93 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154
 
-PUSHOVER_DEBUG="${PUSHOVER_DEBUG:-"false"}"
+PUSHOVER_DEBUG="$${PUSHOVER_DEBUG:-"false"}"
 # kubectl port-forward service/radarr -n default 7878:80
 # export PUSHOVER_TOKEN="";
 # export PUSHOVER_USER_KEY="";
 # export radarr_eventtype=Download;
 # ./notify.sh
 
-CONFIG_FILE="/config/config.xml" && [[ "${PUSHOVER_DEBUG}" == "true" ]] && CONFIG_FILE="config.xml"
+CONFIG_FILE="/config/config.xml" && [[ "$${PUSHOVER_DEBUG}" == "true" ]] && CONFIG_FILE="config.xml"
 ERRORS=()
 
 #
 # Configurable variables
 #
 # Required
-PUSHOVER_USER_KEY="${PUSHOVER_USER_KEY:-}" && [[ -z "${PUSHOVER_USER_KEY}" ]] && ERRORS+=("PUSHOVER_USER_KEY not defined")
-PUSHOVER_TOKEN="${PUSHOVER_TOKEN:-}" && [[ -z "${PUSHOVER_TOKEN}" ]] && ERRORS+=("PUSHOVER_TOKEN not defined")
+PUSHOVER_USER_KEY="$${PUSHOVER_USER_KEY:-}" && [[ -z "$${PUSHOVER_USER_KEY}" ]] && ERRORS+=("PUSHOVER_USER_KEY not defined")
+PUSHOVER_TOKEN="$${PUSHOVER_TOKEN:-}" && [[ -z "$${PUSHOVER_TOKEN}" ]] && ERRORS+=("PUSHOVER_TOKEN not defined")
 # Optional
-PUSHOVER_DEVICE="${PUSHOVER_DEVICE:-}"
-PUSHOVER_PRIORITY="${PUSHOVER_PRIORITY:-"-2"}"
-PUSHOVER_SOUND="${PUSHOVER_SOUND:-}"
+PUSHOVER_DEVICE="$${PUSHOVER_DEVICE:-}"
+PUSHOVER_PRIORITY="$${PUSHOVER_PRIORITY:-"-2"}"
+PUSHOVER_SOUND="$${PUSHOVER_SOUND:-}"
 
 #
 # Print defined variables
 #
-for pushover_vars in ${!PUSHOVER_*}
+for pushover_vars in $${!PUSHOVER_*}
 do
-    declare -n var="${pushover_vars}"
-    [[ -n "${var}" && "${PUSHOVER_DEBUG}" = "true" ]] && printf "%s - %s=%s\n" "$(date)" "${!var}" "${var}"
+    declare -n var="$${pushover_vars}"
+    [[ -n "$${var}" && "$${PUSHOVER_DEBUG}" = "true" ]] && printf "%s - %s=%s\n" "$(date)" "$${!var}" "$${var}"
 done
 
 #
 # Validate required variables are set
 #
-if [ ${#ERRORS[@]} -gt 0 ]; then
-    for err in "${ERRORS[@]}"; do printf "%s - Undefined variable %s\n" "$(date)" "${err}" >&2; done
+if [ $${#ERRORS[@]} -gt 0 ]; then
+    for err in "$${ERRORS[@]}"; do printf "%s - Undefined variable %s\n" "$(date)" "$${err}" >&2; done
     exit 1
 fi
 
 #
 # Send Notification on Test
 #
-if [[ "${radarr_eventtype:-}" == "Test" ]]; then
+if [[ "$${radarr_eventtype:-}" == "Test" ]]; then
     PUSHOVER_TITLE="Test Notification"
-    PUSHOVER_MESSAGE="Howdy this is a test notification from ${radarr_instancename:-Radarr}"
+    PUSHOVER_MESSAGE="Howdy this is a test notification from $${radarr_instancename:-Radarr}"
 fi
 
 #
 # Send notification on Download or Upgrade
 #
-if [[ "${radarr_eventtype:-}" == "Download" ]]; then
-    if [[ "${radarr_isupgrade}" == "True" ]]; then pushover_title="Upgraded"; else pushover_title="Downloaded"; fi
-    printf -v PUSHOVER_TITLE "Movie %s" "${pushover_title}"
+if [[ "$${radarr_eventtype:-}" == "Download" ]]; then
+    if [[ "$${radarr_isupgrade}" == "True" ]]; then pushover_title="Upgraded"; else pushover_title="Downloaded"; fi
+    printf -v PUSHOVER_TITLE "Movie %s" "$${pushover_title}"
     printf -v PUSHOVER_MESSAGE "<b>%s (%s)</b><small>\n%s</small><small>\n\n<b>Client:</b> %s</small><small>\n<b>Quality:</b> %s</small><small>\n<b>Size:</b> %s</small>" \
-        "${radarr_movie_title}" \
-        "${radarr_movie_year}" \
-        "${radarr_movie_overview}" \
-        "${radarr_download_client}" \
-        "${radarr_moviefile_quality}" \
-        "$(numfmt --to iec --format "%8.2f" "${radarr_release_size}")"
-    printf -v PUSHOVER_URL "%s/movie/%s" "${radarr_applicationurl:-localhost}" "${radarr_movie_tmdbid}"
-    printf -v PUSHOVER_URL_TITLE "View movie in %s" "${radarr_instancename:-Radarr}"
+        "$${radarr_movie_title}" \
+        "$${radarr_movie_year}" \
+        "$${radarr_movie_overview}" \
+        "$${radarr_download_client}" \
+        "$${radarr_moviefile_quality}" \
+        "$(numfmt --to iec --format "%8.2f" "$${radarr_release_size}")"
+    printf -v PUSHOVER_URL "%s/movie/%s" "$${radarr_applicationurl:-localhost}" "$${radarr_movie_tmdbid}"
+    printf -v PUSHOVER_URL_TITLE "View movie in %s" "$${radarr_instancename:-Radarr}"
 fi
 
 #
 # Send notification on Manual Interaction Required
 #
-if [[ "${radarr_eventtype:-}" == "ManualInteractionRequired" ]]; then
+if [[ "$${radarr_eventtype:-}" == "ManualInteractionRequired" ]]; then
     PUSHOVER_PRIORITY="1"
     printf -v PUSHOVER_TITLE "Movie requires manual interaction"
     printf -v PUSHOVER_MESSAGE "<b>%s (%s)</b><small>\n<b>Client:</b> %s</small>" \
-        "${radarr_movie_title}" \
-        "${radarr_movie_year}" \
-        "${radarr_download_client}"
-    printf -v PUSHOVER_URL "%s/activity/queue" "${radarr_applicationurl:-localhost}"
-    printf -v PUSHOVER_URL_TITLE "View queue in %s" "${radarr_instancename:-Radarr}"
+        "$${radarr_movie_title}" \
+        "$${radarr_movie_year}" \
+        "$${radarr_download_client}"
+    printf -v PUSHOVER_URL "%s/activity/queue" "$${radarr_applicationurl:-localhost}"
+    printf -v PUSHOVER_URL_TITLE "View queue in %s" "$${radarr_instancename:-Radarr}"
 fi
 
 notification=$(jq -n \
-    --arg token "${PUSHOVER_TOKEN}" \
-    --arg user "${PUSHOVER_USER_KEY}" \
-    --arg title "${PUSHOVER_TITLE}" \
-    --arg message "${PUSHOVER_MESSAGE}" \
-    --arg url "${PUSHOVER_URL}" \
-    --arg url_title "${PUSHOVER_URL_TITLE}" \
-    --arg priority "${PUSHOVER_PRIORITY}" \
-    --arg sound "${PUSHOVER_SOUND}" \
-    --arg device "${PUSHOVER_DEVICE}" \
+    --arg token "$${PUSHOVER_TOKEN}" \
+    --arg user "$${PUSHOVER_USER_KEY}" \
+    --arg title "$${PUSHOVER_TITLE}" \
+    --arg message "$${PUSHOVER_MESSAGE}" \
+    --arg url "$${PUSHOVER_URL}" \
+    --arg url_title "$${PUSHOVER_URL_TITLE}" \
+    --arg priority "$${PUSHOVER_PRIORITY}" \
+    --arg sound "$${PUSHOVER_SOUND}" \
+    --arg device "$${PUSHOVER_DEVICE}" \
     --arg html "1" \
     '{token: $token, user: $user, title: $title, message: $message, url: $url, url_title: $url_title, priority: $priority, sound: $sound, device: $device, html: $html}' \
 )
@@ -97,13 +97,13 @@ status_code=$(curl \
     --silent \
     --output /dev/null \
     --header "Content-Type: application/json" \
-    --data-binary "${notification}" \
+    --data-binary "$${notification}" \
     --request POST "https://api.pushover.net/1/messages.json" \
 )
 
-if [[ "${status_code}" -ne 200 ]] ; then
-    printf "%s - Unable to send notification with status code %s and payload: %s\n" "$(date)" "${status_code}" "$(echo "${notification}" | jq -c)" >&2
+if [[ "$${status_code}" -ne 200 ]] ; then
+    printf "%s - Unable to send notification with status code %s and payload: %s\n" "$(date)" "$${status_code}" "$(echo "$${notification}" | jq -c)" >&2
     exit 1
 else
-    printf "%s - Sent notification with status code %s and payload: %s\n" "$(date)" "${status_code}" "$(echo "${notification}" | jq -c)"
+    printf "%s - Sent notification with status code %s and payload: %s\n" "$(date)" "$${status_code}" "$(echo "$${notification}" | jq -c)"
 fi

--- a/kubernetes/apps/default/sonarr/app/resources/pushover-notify.sh
+++ b/kubernetes/apps/default/sonarr/app/resources/pushover-notify.sh
@@ -1,92 +1,92 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154
 
-PUSHOVER_DEBUG="${PUSHOVER_DEBUG:-"false"}"
+PUSHOVER_DEBUG="$${PUSHOVER_DEBUG:-"false"}"
 # kubectl port-forward service/sonarr -n default 8989:80
 # export PUSHOVER_TOKEN="";
 # export PUSHOVER_USER_KEY="";
 # export sonarr_eventtype=Download;
 # ./pushover-notify.sh
 
-CONFIG_FILE="/config/config.xml" && [[ "${PUSHOVER_DEBUG}" == "true" ]] && CONFIG_FILE="config.xml"
+CONFIG_FILE="/config/config.xml" && [[ "$${PUSHOVER_DEBUG}" == "true" ]] && CONFIG_FILE="config.xml"
 ERRORS=()
 
 #
 # Configurable variables
 #
 # Required
-PUSHOVER_USER_KEY="${PUSHOVER_USER_KEY:-}" && [[ -z "${PUSHOVER_USER_KEY}" ]] && ERRORS+=("PUSHOVER_USER_KEY not defined")
-PUSHOVER_TOKEN="${PUSHOVER_TOKEN:-}" && [[ -z "${PUSHOVER_TOKEN}" ]] && ERRORS+=("PUSHOVER_TOKEN not defined")
+PUSHOVER_USER_KEY="$${PUSHOVER_USER_KEY:-}" && [[ -z "$${PUSHOVER_USER_KEY}" ]] && ERRORS+=("PUSHOVER_USER_KEY not defined")
+PUSHOVER_TOKEN="$${PUSHOVER_TOKEN:-}" && [[ -z "$${PUSHOVER_TOKEN}" ]] && ERRORS+=("PUSHOVER_TOKEN not defined")
 # Optional
-PUSHOVER_DEVICE="${PUSHOVER_DEVICE:-}"
-PUSHOVER_PRIORITY="${PUSHOVER_PRIORITY:-"-2"}"
-PUSHOVER_SOUND="${PUSHOVER_SOUND:-}"
+PUSHOVER_DEVICE="$${PUSHOVER_DEVICE:-}"
+PUSHOVER_PRIORITY="$${PUSHOVER_PRIORITY:-"-2"}"
+PUSHOVER_SOUND="$${PUSHOVER_SOUND:-}"
 
 #
 # Print defined variables
 #
-for pushover_vars in ${!PUSHOVER_*}
+for pushover_vars in $${!PUSHOVER_*}
 do
-    declare -n var="${pushover_vars}"
-    [[ -n "${var}" && "${PUSHOVER_DEBUG}" = "true" ]] && printf "%s - %s=%s\n" "$(date)" "${!var}" "${var}"
+    declare -n var="$${pushover_vars}"
+    [[ -n "$${var}" && "$${PUSHOVER_DEBUG}" = "true" ]] && printf "%s - %s=%s\n" "$(date)" "$${!var}" "$${var}"
 done
 
 #
 # Validate required variables are set
 #
-if [ ${#ERRORS[@]} -gt 0 ]; then
-    for err in "${ERRORS[@]}"; do printf "%s - Undefined variable %s\n" "$(date)" "${err}" >&2; done
+if [ $${#ERRORS[@]} -gt 0 ]; then
+    for err in "$${ERRORS[@]}"; do printf "%s - Undefined variable %s\n" "$(date)" "$${err}" >&2; done
     exit 1
 fi
 
 #
 # Send Notification on Test
 #
-if [[ "${sonarr_eventtype:-}" == "Test" ]]; then
+if [[ "$${sonarr_eventtype:-}" == "Test" ]]; then
     PUSHOVER_TITLE="Test Notification"
-    PUSHOVER_MESSAGE="Howdy this is a test notification from ${sonarr_instancename:-Sonarr}"
+    PUSHOVER_MESSAGE="Howdy this is a test notification from $${sonarr_instancename:-Sonarr}"
 fi
 
 #
 # Send notification on Download or Upgrade
 #
-if [[ "${sonarr_eventtype:-}" == "Download" ]]; then
-    if [[ "${sonarr_isupgrade}" == "True" ]]; then pushover_title="Upgraded"; else pushover_title="Downloaded"; fi
-    printf -v PUSHOVER_TITLE "Episode %s" "${pushover_title}"
+if [[ "$${sonarr_eventtype:-}" == "Download" ]]; then
+    if [[ "$${sonarr_isupgrade}" == "True" ]]; then pushover_title="Upgraded"; else pushover_title="Downloaded"; fi
+    printf -v PUSHOVER_TITLE "Episode %s" "$${pushover_title}"
     printf -v PUSHOVER_MESSAGE "<b>%s (S%02dE%02d)</b><small>\n%s</small><small>\n\n<b>Client:</b> %s</small><small>\n<b>Quality:</b> %s</small>" \
-        "${sonarr_series_title}" \
-        "${sonarr_episodefile_seasonnumber}" \
-        "${sonarr_episodefile_episodenumbers}" \
-        "${sonarr_episodefile_episodetitles}" \
-        "${sonarr_download_client}" \
-        "${sonarr_episodefile_quality}"
-    printf -v PUSHOVER_URL "%s/series/%s" "${sonarr_applicationurl:-localhost}" "${sonarr_series_titleslug}"
-    printf -v PUSHOVER_URL_TITLE "View series in %s" "${sonarr_instancename:-Sonarr}"
+        "$${sonarr_series_title}" \
+        "$${sonarr_episodefile_seasonnumber}" \
+        "$${sonarr_episodefile_episodenumbers}" \
+        "$${sonarr_episodefile_episodetitles}" \
+        "$${sonarr_download_client}" \
+        "$${sonarr_episodefile_quality}"
+    printf -v PUSHOVER_URL "%s/series/%s" "$${sonarr_applicationurl:-localhost}" "$${sonarr_series_titleslug}"
+    printf -v PUSHOVER_URL_TITLE "View series in %s" "$${sonarr_instancename:-Sonarr}"
 fi
 
 #
 # Send notification on Manual Interaction Required
 #
-if [[ "${sonarr_eventtype:-}" == "ManualInteractionRequired" ]]; then
+if [[ "$${sonarr_eventtype:-}" == "ManualInteractionRequired" ]]; then
     PUSHOVER_PRIORITY="1"
     printf -v PUSHOVER_TITLE "Episode requires manual interaction"
     printf -v PUSHOVER_MESSAGE "<b>%s</b><small>\n<b>Client:</b> %s</small>" \
-        "${sonarr_series_title}" \
-        "${sonarr_download_client}"
-    printf -v PUSHOVER_URL "%s/activity/queue" "${sonarr_applicationurl:-localhost}"
-    printf -v PUSHOVER_URL_TITLE "View queue in %s" "${sonarr_instancename:-Sonarr}"
+        "$${sonarr_series_title}" \
+        "$${sonarr_download_client}"
+    printf -v PUSHOVER_URL "%s/activity/queue" "$${sonarr_applicationurl:-localhost}"
+    printf -v PUSHOVER_URL_TITLE "View queue in %s" "$${sonarr_instancename:-Sonarr}"
 fi
 
 notification=$(jq -n \
-    --arg token "${PUSHOVER_TOKEN}" \
-    --arg user "${PUSHOVER_USER_KEY}" \
-    --arg title "${PUSHOVER_TITLE}" \
-    --arg message "${PUSHOVER_MESSAGE}" \
-    --arg url "${PUSHOVER_URL}" \
-    --arg url_title "${PUSHOVER_URL_TITLE}" \
-    --arg priority "${PUSHOVER_PRIORITY}" \
-    --arg sound "${PUSHOVER_SOUND}" \
-    --arg device "${PUSHOVER_DEVICE}" \
+    --arg token "$${PUSHOVER_TOKEN}" \
+    --arg user "$${PUSHOVER_USER_KEY}" \
+    --arg title "$${PUSHOVER_TITLE}" \
+    --arg message "$${PUSHOVER_MESSAGE}" \
+    --arg url "$${PUSHOVER_URL}" \
+    --arg url_title "$${PUSHOVER_URL_TITLE}" \
+    --arg priority "$${PUSHOVER_PRIORITY}" \
+    --arg sound "$${PUSHOVER_SOUND}" \
+    --arg device "$${PUSHOVER_DEVICE}" \
     --arg html "1" \
     '{token: $token, user: $user, title: $title, message: $message, url: $url, url_title: $url_title, priority: $priority, sound: $sound, device: $device, html: $html}' \
 )
@@ -96,13 +96,13 @@ status_code=$(curl \
     --silent \
     --output /dev/null \
     --header "Content-Type: application/json" \
-    --data-binary "${notification}" \
+    --data-binary "$${notification}" \
     --request POST "https://api.pushover.net/1/messages.json" \
 )
 
-if [[ "${status_code}" -ne 200 ]] ; then
-    printf "%s - Unable to send notification with status code %s and payload: %s\n" "$(date)" "${status_code}" "$(echo "${notification}" | jq -c)" >&2
+if [[ "$${status_code}" -ne 200 ]] ; then
+    printf "%s - Unable to send notification with status code %s and payload: %s\n" "$(date)" "$${status_code}" "$(echo "$${notification}" | jq -c)" >&2
     exit 1
 else
-    printf "%s - Sent notification with status code %s and payload: %s\n" "$(date)" "${status_code}" "$(echo "${notification}" | jq -c)"
+    printf "%s - Sent notification with status code %s and payload: %s\n" "$(date)" "$${status_code}" "$(echo "$${notification}" | jq -c)"
 fi

--- a/kubernetes/apps/observability/alloy/app/configmap.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap.yaml
@@ -266,7 +266,7 @@ data:
         source_labels = ["instance"]
         target_label = "node"
         regex = "([^:]+):.*"
-        replacement = "${1}"
+        replacement = "$${1}"
       }
     }
 

--- a/kubernetes/apps/observability/exporters/mqtt-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/mqtt-exporter/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               MQTT_ADDRESS: mosquitto.database.svc.cluster.local
               MQTT_V5_PROTOCOL: false
               PROMETHEUS_PORT: &port 3321
-              TZ: ${TIMEZONE}
+              TZ: America/Chicago
               ZIGBEE2MQTT_AVAILABILITY: true
             envFrom:
               - secretRef:

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -12,8 +12,8 @@ ui:
 alerting:
   pushover:
     title: Gatus
-    application-token: ${PUSHOVER_TOKEN}
-    user-key: ${PUSHOVER_USER_KEY}
+    application-token: $${PUSHOVER_TOKEN}
+    user-key: $${PUSHOVER_USER_KEY}
     priority: 1
     default-alert:
       description: health-check failed

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -42,7 +42,8 @@ spec:
         s3:
           # Credentials are injected via env (loki-secret) and expanded by Loki
           # at runtime (-config.expand-env). The $$ escapes Flux postBuild
-          # substitution so a literal ${VAR} reaches the container.
+          # substitution so a literal dollar-brace reference reaches the
+          # container instead of being substituted at build time.
           endpoint: "$${R2_ENDPOINT}"
           region: auto
           accessKeyId: "$${AWS_ACCESS_KEY_ID}"


### PR DESCRIPTION
## Cause

**flux-operator/flux-instance v0.57.0** (#1375, #1376) pulled kustomize-controller to **v1.9.4**, where `StrictPostBuildSubstitutions` now defaults to **on**. We don't set that feature gate, so we inherited the new default:

```
--feature-gates=ObjectLevelWorkloadIdentity=false     # StrictPostBuild... not set -> default
```

Five Kustomizations started failing:

```
default/bazarr                ${PLEX_TOKEN}
default/homarr                ${TIMEZONE}
observability/mqtt-exporter   ${TIMEZONE}
observability/gatus           ${PUSHOVER_TOKEN}
observability/alloy           ${1}
```

## Strict mode exposed pre-existing bugs — it didn't cause them

Previously an undefined variable was silently replaced with an **empty string**. So these have been broken all along, just quietly:

| what shipped | consequence |
|---|---|
| `X-Plex-Token=` in subcleaner.sh | token blanked at build time — the runtime value from `bazarr-secret` never applied, so **Plex library refresh has never worked** |
| `replacement = ""` in alloy | regex capture group blanked — the `node` label was never populated |
| `TZ: ""` in homarr + mqtt-exporter | `TIMEZONE` was never defined anywhere |
| `HOME_ASSISTANT_TRUSTED_PROXIES: ""` | `CLUSTER_POD_CIDR` was never defined either |

Turning the gate back off would restore the silence, not the correctness. So this fixes the substitutions instead.

## Fixes by category

**Escape `$${VAR}`** — runtime shell/app expansion. Verified these files contain **zero** Flux substitution variables, so escaping wholesale is safe:

- `bazarr/subcleaner.sh`, `radarr/pushover-notify.sh`, `sonarr/pushover-notify.sh`, `cert-exporter/export.sh`
- `gatus/config.yaml` — selectively; `${SECRET_DOMAIN}` is a real Flux var and stays substitutable
- `alloy/configmap.yaml` — the `${1}` regex capture group

**Define** — these were genuinely missing variables, not literals:

- `TIMEZONE` → replaced with literal `America/Chicago` (what the other 30 apps use)
- `CLUSTER_POD_CIDR` → added to `homeassistant/ks.yaml` as `10.42.0.0/16` (matches `cluster-cidr` from the live cluster)

Also rewords a loki comment containing a literal `${VAR}` — harmless in practice since kustomize strips comments, but it made the repo-wide audit noisy.

## Verification

**Escape semantics confirmed against a deployed resource, not assumed.** The `health-review` ConfigMap has `$${LOKI}` in git and renders as literal `${LOKI}` in the cluster today — same resource type, same pattern, already working:

```
$ kubectl get cm -n observability health-review-scripts -o yaml | grep -oE '\$?\$\{...\}'
${LOKI}
${PROM}
${PUSHOVER_TOKEN}
${PUSHOVER_USER}
```

(GNU `envsubst` handles `$${VAR}` differently from Flux's Go implementation, so a local envsubst test is *not* representative — this is why I checked the cluster.)

A repo-wide sweep for bare undefined `${VAR}` now returns clean. `task validate` passes.

## Scope note

The audit found ~70 `${...}` occurrences, but most use `${VAR:-default}` form which envsubst resolves happily. Only bare `${VAR}` without a default fails strict mode — that narrowed it to the 10 files changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)