### PR TITLE
fix(cilium,volsync): disableWait for metal-08, clear stale restic locks

### DIFF
--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -38,3 +38,8 @@ spec:
       VOLSYNC_GID: "65536"
       VOLSYNC_FSGROUP: "65536"
       VOLSYNC_MEMORY_LIMIT: 4Gi
+      # Bumped 2026-08-04 to clear a stale restic lock left by mover pod
+      # volsync-src-plex-r2-tfl2m on 2026-07-20. The backup itself kept
+      # succeeding; only the `forget` retention step failed, so ~15 days of
+      # snapshots accumulated unpruned.
+      VOLSYNC_UNLOCK: "2"

--- a/kubernetes/apps/default/romm/ks.yaml
+++ b/kubernetes/apps/default/romm/ks.yaml
@@ -38,3 +38,6 @@ spec:
       VOLSYNC_GID: "1000"
       VOLSYNC_FSGROUP: "1000"
       VOLSYNC_MEMORY_LIMIT: 4Gi
+      # Bumped 2026-08-04 to clear a stale restic lock left by mover pod
+      # volsync-src-romm-r2-pt4ts on 2026-08-04 00:11.
+      VOLSYNC_UNLOCK: "2"

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -9,11 +9,23 @@ spec:
     kind: OCIRepository
     name: cilium
   interval: 30m
+  # metal-08 is a control-plane node that is intentionally offline for the
+  # garage-rack buildout and is not returning soon. Its node object still
+  # exists, so every DaemonSet keeps a Pending pod there and never reports
+  # fully available — cilium and cilium-envoy sit at 9/10 permanently. That is
+  # the healthy steady state for this cluster, not a failure.
+  #
+  # Without disableWait, Helm blocks on "DaemonSet/kube-system/cilium status:
+  # 'InProgress'" until it times out, fails the release, and takes
+  # cilium-gateway and node-local-dns down with it via dependsOn — while
+  # cilium itself is running fine (20 pods Ready, networking healthy).
   install:
+    disableWait: true
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
@@ -9,11 +9,16 @@ spec:
     kind: OCIRepository
     name: prometheus-smartctl-exporter
   interval: 30m
+  # DaemonSet — sits at 9/10 forever because metal-08 is intentionally offline.
+  # See the cilium HelmRelease for the full explanation; without disableWait
+  # Helm blocks on the DaemonSet rollout and fails the release.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    disableWait: true
     remediation:
       strategy: rollback
       retries: 3


### PR DESCRIPTION
Two unrelated fixes, both surfaced once the CSI outage cleared.

## cilium + smartctl-exporter — `disableWait`

metal-08 is a control-plane node intentionally offline for the garage-rack buildout and **not returning soon**. Its node object still exists, so every DaemonSet keeps a `Pending` pod there and never reports fully available:

```
cilium          desired=10  ready=9
cilium-envoy    desired=10  ready=9
smartctl        desired=10  ready=9
```

**9/10 is the healthy steady state for this cluster, not a failure.** Helm doesn't know that — it blocked on `DaemonSet/kube-system/cilium status: 'InProgress'` until timeout, failed the release, and took `cilium-gateway` and `node-local-dns` down with it via `dependsOn`.

Meanwhile cilium itself was running fine: **20 pods Ready, networking healthy**. Nothing was actually broken except Helm's opinion of it.

Setting `install.disableWait` and `upgrade.disableWait` on both — the same workaround already applied to kube-prometheus-stack for this node.

## plex + romm — stale restic locks

**plex-r2 had not completed a sync since 2026-07-19 — sixteen days.**

The backup itself kept succeeding (`snapshot 7db489c9 saved`); the follow-on `forget` failed every run:

```
unable to create lock in backend: repository is already locked by PID 32 on
volsync-src-plex-r2-tfl2m
lock was created at 2026-07-20 (373h4m ago)
```

The holding mover pod is long gone — the lock is stale. So **retention hasn't run in over two weeks** and snapshots have been accumulating unpruned in R2. romm has the same failure from a lock created 2026-08-04 00:11.

Bumping `VOLSYNC_UNLOCK` for both, using the mechanism already documented in `components/volsync/r2.yaml`: the mover runs `restic unlock` then the backup in the same pod, and volsync only re-runs it when the value changes.

## Not fixed here — needs a pod delete, not config

`volsync-src-recyclarr-r2` is stuck on a stale mount error from during the outage:

```
driver name rook-ceph.rbd.csi.ceph.com not found in the list of registered CSI drivers
```

The nodeplugin on metal-01 is healthy now (3/3, 289d) and the `CSIDriver` object is registered — the pod is just holding a cached failure. It needs deleting so volsync recreates it:

```bash
kubectl delete pod -n default volsync-src-recyclarr-r2-d62xw
```

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)