### PR TITLE
Revert "feat(container)!: Update docker.io/library/postgres (#1430)"

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
       image:
         registry: docker.io
         repository: library/postgres
-        tag: 18.4-alpine
+        tag: 17.10-alpine
       auth:
         existingSecret: authentik
         secretKeys:
@@ -76,7 +76,7 @@ spec:
         enabled: false
       initContainers:
         - name: wait-for-postgresql
-          image: docker.io/library/postgres:18-alpine
+          image: docker.io/library/postgres:17-alpine
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -99,7 +99,7 @@ spec:
         minReplicas: 2
       initContainers:
         - name: wait-for-postgresql
-          image: docker.io/library/postgres:18-alpine
+          image: docker.io/library/postgres:17-alpine
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
**SSO is down.** Merge when convenient.

## What broke

#1430 bumped authentik's PostgreSQL image 17 → 18. **PostgreSQL major upgrades require `pg_upgrade` to convert the data directory** — swapping the image alone doesn't work.

`authentik-postgresql-0` has been in CrashLoopBackOff (25+ restarts) since:

```
FATAL:  database files are incompatible with server
DETAIL: The data directory was initialized by PostgreSQL version 17,
        which is not compatible with this version 18.4.
```

`authentik-server` is down with it — which means SSO is unavailable for every app behind the Envoy forward-auth SecurityPolicy.

## Data is safe

The v17 data directory is untouched; a v18 server simply refuses to open it. **Reverting the image restores service with no data work required.**

## The change

A clean `git revert` of 99aab648, restoring the exact prior pins:

```
tag: 17.10-alpine
image: docker.io/library/postgres:17-alpine   (×2 initContainers)
```

Verified no other app in the repo was on postgres 18 — authentik was the only one affected.

## Moving to 18 properly

Back up, run `pg_upgrade` (or dump/restore) against the data directory, *then* bump the image. That's a planned maintenance task, not a tag change.

Worth adding a Renovate rule so postgres majors aren't proposed for this HelmRelease at all — same shape as limiting rook-ceph to single-minor steps. Two incidents in one day from majors that can't be applied by image swap alone.

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)