### PR TITLE
feat(renovate): guard upgrades that need a migration, not a tag change

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,9 @@
     'github>sob/home-ops//.github/renovate/groups.json5',
     'github>sob/home-ops//.github/renovate/labels.json5',
     'github>sob/home-ops//.github/renovate/semanticCommits.json5',
+    // Listed last so its automerge:false / enabled:false wins over any
+    // permissive rule above it (packageRules are last-match-wins).
+    'github>sob/home-ops//.github/renovate/upgradePolicy.json5',
   ],
   dependencyDashboard: true,
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',

--- a/.github/renovate/upgradePolicy.json5
+++ b/.github/renovate/upgradePolicy.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Upgrades that CANNOT be applied by changing an image tag alone.
+  //
+  // On 2026-08-04 two of these landed in one batch and both broke production:
+  //
+  //   rook-ceph 1.18.4 -> 1.20.3   Rook supports single-minor upgrades only.
+  //                                Renovate offered two minors as one tidy PR;
+  //                                ceph-csi was down ~8h.
+  //   postgres 17 -> 18            A major PG upgrade needs pg_upgrade or a
+  //                                dump/restore. The image swap alone left
+  //                                authentik-postgresql in CrashLoopBackOff
+  //                                ("database files are incompatible with
+  //                                server") and took SSO down with it.
+  //
+  // automerge:false already forced a human to look at both, and it worked —
+  // neither merged unattended. What was missing is that nothing distinguished
+  // "needs a migration" from an ordinary major. These rules encode that.
+  "packageRules": [
+    // Rook: never offer more than one minor at a time.
+    // separateMultipleMinor makes Renovate raise a PR per minor stream, so a
+    // 1.18 -> 1.20 jump arrives as 1.19 first and then 1.20, which is the only
+    // upgrade path Rook actually supports. Operator and cluster charts are
+    // bumped together by the rook-ceph group in groups.json5.
+    {
+      "description": "rook-ceph: one minor at a time (Rook does not support skipping minors)",
+      "matchPackageNames": [
+        "/^ghcr\\.io/rook/rook-ceph$/",
+        "/^ghcr\\.io/rook/rook-ceph-cluster$/",
+      ],
+      "separateMultipleMinor": true,
+      "separateMinorPatch": true,
+      "automerge": false,
+      "dependencyDashboardApproval": true,
+    },
+
+    // PostgreSQL majors: do not raise PRs at all.
+    // The data directory is written by a specific major and a new server
+    // refuses to open it, so the upgrade is a planned maintenance task
+    // (pg_upgrade, or dump + restore into a fresh data dir) and not something
+    // to accept from a bot. Minor and patch updates are unaffected and still
+    // flow normally.
+    //
+    // To upgrade deliberately: take a verified dump, bump the tag by hand, and
+    // restore. See the 2026-08-05 authentik 17 -> 18.4 upgrade for the runbook.
+    {
+      "description": "postgres majors need pg_upgrade — never propose them automatically",
+      "matchPackageNames": [
+        "/^docker\\.io/library/postgres$/",
+        "/postgres$/",
+        "/postgresql$/",
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+    },
+  ]
+}


### PR DESCRIPTION
Two majors landed in one batch on 2026-08-04 and both broke production, because neither can be applied by changing an image tag:

| update | what went wrong |
|---|---|
| **rook-ceph 1.18.4 → 1.20.3** | Rook supports **single-minor upgrades only**, but Renovate offered two minors as one tidy PR. A v1.16-pinned operator then managed 1.20-era ceph-csi RBAC — every node plugin died. **~8h outage, 12 pods unable to mount.** |
| **postgres 17 → 18** | A major PG upgrade needs `pg_upgrade` or dump/restore. The image swap left `authentik-postgresql` in CrashLoopBackOff (`database files are incompatible with server`) and **took SSO down**. |

`automerge: false` already forced a human to review both, and **that part worked** — neither merged unattended. What was missing is that nothing distinguished *"this needs a migration"* from an ordinary major.

## Two rules

**rook-ceph** — `separateMultipleMinor` + `separateMinorPatch`, so a 1.18 → 1.20 jump arrives as 1.19 first, then 1.20. That's the only path Rook supports, and it makes the safe sequence the default rather than something you have to know. Still requires dashboard approval.

**postgres majors** — `enabled: false`, so no PR is raised at all. The data directory is written by a specific major and a new server refuses to open it, so this is planned maintenance, not something to accept from a bot. **Minor and patch updates are unaffected.**

Loaded last in `renovate.json5` so these override permissive rules above them (`packageRules` are last-match-wins).

## Note

This is a policy change only — it can't be proven correct until the next Renovate run. The check is that rook offers 1.19 rather than 1.20, and that no postgres major PR appears.

`task validate` passes (132s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)