### PR TITLE
fix(rook-ceph): move Ceph version pin to cephImage for chart 1.19

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -81,18 +81,29 @@ spec:
       osd_class_update_on_start = false
       mon_max_pg_per_osd = 300
 
+    # Pin the Ceph daemon version explicitly. Without this it comes from the
+    # chart default, so a Rook chart bump silently carries a Ceph version with
+    # it — chart 1.20.3 defaults to v20.2.2 and would start a major Ceph
+    # 19 -> 20 upgrade that nobody chose.
+    #
+    # This lives at the top-level cephImage key, NOT cephClusterSpec.cephVersion.
+    # Chart 1.19 added cephImage and templates cephVersion into the CephCluster
+    # from it, so setting both produces a duplicate key and the release fails
+    # with: yaml: unmarshal errors: mapping key "cephVersion" already defined.
+    # The chart values say plainly: "If specifying these values, do not include
+    # the cephVersion section in the cephClusterSpec."
+    #
+    # Ceph upgrades are an explicit edit to `tag` here, never a side effect of a
+    # Rook bump, and must be done separately from a Rook version change.
+    # allowUnsupported stays false — moving to Ceph v20 (Tentacle) would require
+    # setting it true, which is exactly the kind of decision that should be
+    # deliberate rather than inherited from a chart default.
+    cephImage:
+      repository: quay.io/ceph/ceph
+      tag: v19.2.5
+      allowUnsupported: false
+
     cephClusterSpec:
-      # Pin the Ceph daemon version explicitly. Without this it comes from the
-      # chart default, so a Rook chart bump silently carries a Ceph version with
-      # it — chart 1.20.3 defaulted to v20.2.2 and would have started a major
-      # Ceph 19 -> 20 upgrade that nobody chose. Chart v1.18.4 defaults to
-      # v19.2.3, which is what every mon and OSD is already running, so setting
-      # this is a no-op today and purely stops future drift.
-      #
-      # Ceph upgrades are now an explicit edit here, never a side effect of a
-      # Rook bump, and must be done separately from a Rook version change.
-      cephVersion:
-        image: quay.io/ceph/ceph:v19.2.5
       # Resource definitions
       resources:
         osd:


### PR DESCRIPTION
**Unblocks the v1.19.8 upgrade.** The operator went to v1.19.8 cleanly; only the cluster chart is failing.

## The error

```
error while running post render on files: yaml: unmarshal errors:
  line 17: mapping key "cephVersion" already defined at line 14
```

Chart 1.19 added a top-level `cephImage` value and now templates `cephVersion` into the CephCluster from it. Our pin in `cephClusterSpec.cephVersion` — added to stop Ceph versions riding along with Rook bumps — became a **second definition of the same key**.

The chart values say so directly:

```yaml
# Specify these values to override the Ceph image in the cephClusterSpec below.
# If specifying these values, do not include the cephVersion section in the cephClusterSpec.
cephImage:
```

## The change

Moves the pin to `cephImage.repository`/`tag`, keeping **v19.2.5** — the version every mon, OSD and mgr is already running. Nothing about the deployed Ceph changes.

`allowUnsupported: false` is set explicitly. Ceph v20 (Tentacle) requires it to be `true`, so that upgrade stays a deliberate decision rather than something inherited from a chart default — the same protection the original pin was for, expressed the way 1.19 expects.

## Verification

Rendered chart v1.19.8 with these values:

```
cephVersion occurrences in render: 1
    cephVersion:
      image: "quay.io/ceph/ceph:v19.2.5"
      allowUnsupported: false
```

Exactly one, resolving to the running version. `task validate` passes.

## After merge

```bash
kubectl get helmrelease -n rook-ceph              # both Ready=True
kubectl get cephcluster -n rook-ceph              # Ready / HEALTH_OK
kubectl get pods -n rook-ceph | grep osd          # OSDs back to Running
```

Then #1471 (1.20.3) needs a rebase onto main before it can go — it's still based on `feat/rook-ceph-119` and carries a stale diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)