### PR TITLE
feat(rook-ceph): upgrade Ceph to v20.2.2 (Tentacle), gate future majors

### DIFF
--- a/.github/renovate/upgradePolicy.json5
+++ b/.github/renovate/upgradePolicy.json5
@@ -35,6 +35,25 @@
       "dependencyDashboardApproval": true,
     },
 
+
+    // Ceph daemons: let point releases flow, gate majors.
+    // The version lives at cephImage.tag in the rook-ceph-cluster HelmRelease
+    // and Renovate's helm-values manager already tracks it (it moved
+    // 19.2.3 -> 19.2.5 unattended in #1473, which is the behaviour we want).
+    //
+    // A Ceph MAJOR (e.g. 19 Squid -> 20 Tentacle) rewrites daemon state, rolls
+    // mons/mgrs/OSDs one at a time, and cannot be downgraded. It needs verified
+    // backups and someone watching, so it must never arrive as an ordinary PR.
+    // dependencyDashboardApproval keeps it visible on the dashboard as a
+    // checkbox without ever creating a PR on its own.
+    {
+      "description": "ceph: point releases flow, majors need deliberate approval",
+      "matchPackageNames": ["/^quay\\.io/ceph/ceph$/"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "dependencyDashboardApproval": true,
+    },
+
     // PostgreSQL majors: do not raise PRs at all.
     // The data directory is written by a specific major and a new server
     // refuses to open it, so the upgrade is a planned maintenance task

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -95,12 +95,19 @@ spec:
     #
     # Ceph upgrades are an explicit edit to `tag` here, never a side effect of a
     # Rook bump, and must be done separately from a Rook version change.
-    # allowUnsupported stays false — moving to Ceph v20 (Tentacle) would require
-    # setting it true, which is exactly the kind of decision that should be
-    # deliberate rather than inherited from a chart default.
+    #
+    # allowUnsupported stays false: chart 1.20.3 states "Currently Squid and
+    # Tentacle are supported", so v20 (Tentacle) needs no override. If a future
+    # tag ever requires setting this true, that is a signal to stop and read the
+    # release notes, not to flip the flag.
+    #
+    # Point releases (19.2.5 -> 19.2.6) flow automatically via Renovate.
+    # Majors are gated behind dependencyDashboardApproval in
+    # .github/renovate/upgradePolicy.json5 — they roll mons, mgrs and OSDs one
+    # at a time and cannot be downgraded.
     cephImage:
       repository: quay.io/ceph/ceph
-      tag: v19.2.5
+      tag: v20.2.2
       allowUnsupported: false
 
     cephClusterSpec:


### PR DESCRIPTION
**DRAFT — two blockers below must clear first. A Ceph major is one-way.**

## Answering "allow everything but a major"

Point releases **already flow automatically**. Renovate's `helm-values` manager tracks the `repository`/`tag` pair in this HelmRelease — that's how #1473 moved Ceph 19.2.3 → 19.2.5 unattended. Nothing needed there.

What was missing is an explicit gate on majors, so this adds one to `upgradePolicy.json5`:

```json5
{
  "matchPackageNames": ["/^quay\\.io/ceph/ceph$/"],
  "matchUpdateTypes": ["major"],
  "automerge": false,
  "dependencyDashboardApproval": true,
}
```

`dependencyDashboardApproval` rather than `enabled: false` (which is what postgres gets) — you *want* to see that Ceph 21 exists, you just never want it arriving as an ordinary PR. It shows on the dashboard as a checkbox and creates a PR only when you tick it.

Net behaviour:

| update | what happens |
|---|---|
| 20.2.2 → 20.2.3 | PR raised automatically, as today |
| 20.x → 21.x | dashboard checkbox only, never a surprise PR |
| Rook chart bump | cannot move Ceph at all — the pin holds |

## The upgrade itself

`cephImage.tag` v19.2.5 → **v20.2.2**.

Setting the tag explicitly rather than removing the pin. Deleting `cephImage` would fall back to the chart default — which happens to be v20.2.2 today, but that's the same implicit-default behaviour that caused the 2026-08-04 incident. Explicit keeps it a visible one-line diff and keeps future Rook bumps from moving it.

`allowUnsupported` stays **false** — chart 1.20.3 says *"Currently Squid and Tentacle are supported"*, so v20 needs no override. Verified by rendering chart v1.20.3 with these values:

```
cephVersion:
  image: "quay.io/ceph/ceph:v20.2.2"
  allowUnsupported: false
```

Exactly one occurrence.

## Blockers — do not merge until both clear

**1. Ceph is rebuilding.** Fallout from the Rook 1.20.3 OSD restarts:

```
PG_DEGRADED: 40191/160569 objects degraded (25.03%), 157 pgs degraded
```

Wait for `HEALTH_OK`:

```bash
kubectl get cephcluster -n rook-ceph
```

**2. Four volsync backups are stale**, one badly:

```
default/plex-r2         last=2026-07-19   <- 17 days
default/recyclarr-r2    last=2026-08-02
default/enigma-bbs-r2   last=2026-08-04
default/overseerr-r2    last=2026-08-04
```

A Ceph major rewrites daemon state and **cannot be downgraded** — 19 → 20 is one-way. Backups are the only fallback, so they need to be real before starting.

## What to expect on merge

Rook drives a staged rolling upgrade — mons first, then mgrs, then OSDs one at a time, waiting for health between each. With 3 mons and `size: 3` replication there's redundancy throughout, but it's the point of maximum exposure.

```bash
kubectl -n rook-ceph get pods -l app=rook-ceph-osd -w
kubectl get cephcluster -n rook-ceph
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)