### PR TITLE
fix(rook-ceph): revert to v1.19.8 — 1.20.3 breaks volume attachment

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.3
+    tag: v1.19.8
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.3
+    tag: v1.19.8
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
**Volume attachment is broken cluster-wide.** Rook 1.20.3 deployed at 23:07 and nothing has been able to mount a Ceph PVC since.

## The failure

```
rook-ceph.rbd.csi.ceph.com-ctrlplugin      0/2
rook-ceph.cephfs.csi.ceph.com-ctrlplugin   0/2
```

```
pods "rook-ceph.rbd.csi.ceph.com-ctrlplugin-..." is forbidden:
error looking up service account rook-ceph/rbd-ctrlplugin-sa:
serviceaccount "rbd-ctrlplugin-sa" not found
```

The ctrlplugins run the **external-attacher**. With them down, every new mount fails with `Multi-Attach` or `timed out waiting for external-attacher`.

Currently blocked: four volsync backups (plex, recyclarr, enigma-bbs, overseerr) stuck 20+ min in `ContainerCreating`. The same failure blocked grafana earlier tonight.

## Why

Chart 1.20.3 adds a `ceph-csi-operator` subchart that 1.18.11 didn't have:

```yaml
ceph-csi-operator:
  fullnameOverride: ceph-csi
  controllerManager:
    manager:
      env:
        csiServiceAccountPrefix: ""
```

That changes the expected ServiceAccount to `rbd-ctrlplugin-sa`. It doesn't exist — the only CSI service account present is `ceph-csi`.

Worth noting the ctrlplugin deployments date from **2025-10-19**, so this cluster has run the csi-operator model for months. Only the expected SA name changed.

Restarting `ceph-csi-controller-manager` did **not** create the missing accounts — its driver reconcile fails first with repeated conflict errors (`Operation cannot be fulfilled... object has been modified`).

## This change

Reverts Rook to **v1.19.8**, which was verified healthy an hour earlier: both HelmReleases `Ready`, CephCluster `Ready`/`HEALTH_OK`, CSI nodeplugins 9/10, volumes attaching normally.

**Ceph stays pinned at v19.2.5** via `cephImage` — this reverts Rook only.

## After merge

```bash
kubectl get deploy -n rook-ceph | grep ctrlplugin     # expect 2/2
kubectl get pods -n default | grep volsync-src        # should mount and run
```

The stuck movers may need deleting once attachment works, and the four stale `volsync-*-r2-src` PVCs likely need clearing too.

## Getting to 1.20 later

Needs the `ceph-csi-operator` subchart values sorted first — probably `csiServiceAccountPrefix`, or ensuring the subchart creates the per-driver service accounts. That's a config problem to solve deliberately, not during an outage.

**#1484 (Ceph 20) should stay a draft until this is resolved** — it targets chart 1.20.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)