### PR TITLE
fix(volsync): clear stale restic lock on recyclarr

### DIFF
--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -32,3 +32,8 @@ spec:
       VOLSYNC_UID: "1024"
       VOLSYNC_GID: "100"
       VOLSYNC_FSGROUP: "100"
+      # Bumped 2026-08-06 to clear a stale restic lock created 2026-08-03 00:58
+      # when the mover was killed mid-run during the ceph-csi outage. The backup
+      # itself succeeds; only the follow-on forget was failing, so retention has
+      # not run since.
+      VOLSYNC_UNLOCK: "2"


### PR DESCRIPTION
`recyclarr-r2` hasn't completed a sync since **2026-08-02**.

The backup itself succeeds — the follow-on `forget` fails every run:

```
repository is already locked by PID 32 on volsync-src-recyclarr-r2-pt4ts
lock was created at 2026-08-03 00:58:36 (71h ago)
```

The holding mover was killed mid-run during the ceph-csi outage, so the lock is stale and **retention hasn't run in three days**.

Same fix already applied to plex and romm in #1476 — bump `VOLSYNC_UNLOCK` so the mover runs `restic unlock` before the next backup.

`task validate` passes.