### PR TITLE
fix(recyclarr): apply BR-DISK custom format to the Any quality profile

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -269,7 +269,17 @@ radarr:
       # in the library — min_format_score: 0 simply rejects new releases scoring
       # negative. Replacing what is already there needs upgrades enabled on Any
       # and is a separate decision.
+      #
+      # BR-DISK is the same gap, found the hard way. Zootopia 2 was grabbed as a
+      # full UHD Blu-ray disc structure; Radarr imported a single .m2ts playlist
+      # from it — 00036.m2ts, 4.98GB, 12m48s of a 1h48m film, tagged quality
+      # "Unknown" because .m2ts does not parse. Re-searching immediately grabbed
+      # another 79GB disc rip of the same shape.
+      #
+      # BR-DISK was already defined and scored -10000 on Ultra-HD and
+      # HD - 720p/1080p, just never on Any, which is where that movie lived.
       - trash_ids:
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
         quality_profiles:
           - name: Any


### PR DESCRIPTION
## What happened

Zootopia 2 was grabbed as a **full UHD Blu-ray disc structure**, and Radarr imported a single playlist stream out of it:

```
Zootopia 2 (2025) - [Unknown][HDR10][TrueHD Atmos 7.1][h265]-TMT.m2ts
imported as "00036"
```

`ffprobe`:

```
duration = 768s  (12m48s, of a 1h48m film)
size     = 4.98 GB
bitrate  = 51.9 Mbps
video    = HEVC 3840x2160
```

The 4K HDR and TrueHD Atmos are **genuine** — this isn't a fake release. It's a BDMV rip where the main title was never selected. Radarr tagged it quality `Unknown` because `.m2ts` doesn't parse, which is precisely why nothing flagged it.

Deleting the file and re-searching immediately grabbed **another 79.48 GB disc rip** of the same shape. It repeats until the format is actually scored.

## The gap

`BR-DISK` was already defined and scored:

| profile | BR-DISK score |
|---|---|
| Ultra-HD | −10000 |
| HD - 720p/1080p | −10000 |
| Remux/Web 1080p | −10000 |
| **Any** | **0** |

Zootopia 2 is on **`Any`** — along with ~1141 of ~1166 movies.

Exactly the same scoping gap as `LQ` in #1410, which produced the YTS Twisters problem. Same root cause, second instance.

## The change

Adds `BR-DISK` alongside `LQ` for the `Any` profile. With `min_format_score: 0`, disc rips are then rejected outright.

Still deliberately narrow — only `LQ` and `BR-DISK` are assigned to `Any`. Applying the audio, movie-version and release-group blocks there would be a much larger behaviour change across 1141 movies.

## Already done manually

- Bad `.m2ts` deleted (`hasFile=false`)
- Both releases blocklisted — the original grab and the 79 GB re-grab

Re-search once this merges, so the disc rips score negative and a real encode is selected.

`task validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)