### PR TITLE
fix(recyclarr): rename quality_profiles to assign_scores_to for v8

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -125,7 +125,7 @@ sonarr:
           - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02
           - d84935abd3f8556dcd51d4f27e22d0a6  # WEB Tier 03
           - d0c516558625b04b363fa6c5c2c7cfd4  # WEB Scene
-        quality_profiles:
+        assign_scores_to:
           - name: Web 1080p
           - name: Web 720p
           - name: Any
@@ -230,7 +230,7 @@ radarr:
           - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - 2a6039655313bf5dab1e43523b62c374  # MA
           - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
+        assign_scores_to:
           - name: HD - 720p/1080p
           - name: Ultra-HD
       - trash_ids:
@@ -249,7 +249,7 @@ radarr:
           - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
           - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
-        quality_profiles:
+        assign_scores_to:
           - name: HD - 720p/1080p
           - name: Ultra-HD
             score: 0
@@ -281,5 +281,5 @@ radarr:
       - trash_ids:
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
-        quality_profiles:
+        assign_scores_to:
           - name: Any


### PR DESCRIPTION
**Recyclarr has been failing to parse its config entirely** since the 7.4.1 → 8.7.0 major landed today.

```
[ERR] Config parsing failed in recyclarr.yml: The `quality_profiles` element
under `custom_formats` has been renamed to `assign_scores_to`.
See: https://recyclarr.dev/guide/upgrade-guide/v8.0/#assign-scores-to
```

Every sync since has exited without applying anything.

## It failed silently

The CronJob still reported `Complete`, so nothing surfaced it. I only found it by checking why `BR-DISK` was still scored `0` on the `Any` profile after #1487 merged and the ConfigMap had correctly updated.

That means **#1487 never took effect** — and any recyclarr change since the upgrade has been a no-op.

## The change

Renames the four `quality_profiles` keys nested under `custom_formats`. The two top-level `quality_profiles` blocks that *define* the profiles keep their name — only the score-assignment key changed in v8:

```
line  11  quality_profiles:      (sonarr, top-level)     keep
line 128  assign_scores_to:      (sonarr custom_formats) renamed
line 142  quality_profiles:      (radarr, top-level)     keep
line 233  assign_scores_to:      (radarr custom_formats) renamed
line 252  assign_scores_to:      (radarr custom_formats) renamed
line 284  assign_scores_to:      (radarr custom_formats) renamed
```

## Verified against the real image

Ran recyclarr **8.7.0** against this config in-cluster. It now fails only on the expected unset `SONARR_API_KEY` env var rather than the schema error — so the structure parses.

## After merge

Trigger a sync and confirm BR-DISK finally scores on `Any`:

```bash
kubectl create job -n default --from=cronjob/recyclarr recyclarr-manual
# then check Any profile: BR-DISK should be -10000, not 0
```

Then re-search Zootopia 2, Independence Day and Minions — all three are file-less and monitored, waiting for disc rips to score negative.

## Pattern worth noting

Third upgrade today needing a config migration rather than an image swap, after rook-ceph (single-minor only) and postgres (`pg_upgrade`). Unlike those two, **this one failed silently** — the job exited 0.

Worth an alert on recyclarr job output containing `Config parsing failed`, since exit status alone doesn't catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)