### PR TITLE
fix(sabnzbd): move incomplete/ back to NFS — hostPath fails on Talos

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -26,25 +26,6 @@ spec:
       sabnzbd:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          # hostPath dirs are created 0755 root:root by kubelet and fsGroup does
-          # not apply to hostPath volumes, so the app (uid 1031) cannot write to
-          # the mount without this chown.
-          init-incomplete:
-            image:
-              repository: docker.io/library/busybox
-              tag: 1.38.0
-            command: ["/bin/sh", "-c"]
-            args:
-              - |
-                mkdir -p /incomplete
-                chown 1031:65536 /incomplete
-                chmod 0775 /incomplete
-            securityContext:
-              runAsUser: 0
-              runAsNonRoot: false
-              allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
@@ -53,19 +34,32 @@ spec:
             env:
               TZ: America/Chicago
               SABNZBD__PORT: &port 80
-              # Incomplete downloads live on node-local disk instead of NFS.
-              # Measured on this cluster (800MiB dd, iflag=direct for reads):
+              # NOTE: incomplete/ is back on NFS. Moving it to a node-local
+              # hostPath is a real win — measured on this cluster with an 800MiB
+              # dd (iflag=direct on reads), since par2 verify and unpack are
+              # read-heavy:
               #   node-local  1.7 GB/s write   1.7 GB/s read
               #   NFS          91 MB/s write    38 MB/s read
               #   ceph-block   48 MB/s write    18 MB/s read
-              # par2 verify and unpack are read-heavy, so the 38 MB/s NFS read
-              # was the bottleneck. ceph-block is network storage too and
-              # measured worse than NFS, so only node-local helps here.
-              SABNZBD__DOWNLOAD_DIR: /incomplete
-              # /incomplete is on the node EPHEMERAL partition, shared with
-              # container storage. Without a guard a large queue can fill it and
-              # trigger disk-pressure eviction on metal-07. SAB pauses below this
-              # and fulldisk_autoresume=1 resumes automatically.
+              # (ceph-block is network storage too and measured worse than NFS,
+              # so only node-local helps.)
+              #
+              # But hostPath does not work here as-is. Talos gives kubelet a
+              # restricted mount namespace, so it cannot create directories
+              # under /var/mnt even though the path is writable from a normal
+              # pod:
+              #   MountVolume.SetUp failed for volume "incomplete":
+              #   mkdir /var/mnt/sabnzbd-incomplete: read-only file system
+              # That left sabnzbd stuck in Init:0/1 and the *arr reporting
+              # downloadClientUnavailable.
+              #
+              # Doing this properly needs machine.kubelet.extraMounts in
+              # talos/machineconfig.yaml.j2 binding /var/mnt for kubelet, then a
+              # config apply to metal-07. Worth doing as its own change.
+              SABNZBD__DOWNLOAD_DIR: /media/Downloads/sabnzbd/incomplete
+              # Kept regardless of where incomplete/ lives: without a floor a
+              # large queue can fill the volume. SAB pauses below this and
+              # fulldisk_autoresume=1 resumes automatically.
               SABNZBD__DOWNLOAD_FREE: 100G
               # Where SABnzbd looks for post-processing scripts. The script
               # itself still has to be selected per category in Config →
@@ -169,18 +163,6 @@ spec:
         defaultMode: 493
         globalMounts:
           - path: /scripts
-      # Node-local scratch for in-flight downloads. Safe as a hostPath because
-      # the nodeAffinity below pins this pod to nodes labelled
-      # node-role.kubernetes.io/media=true, and metal-07 is currently the only
-      # one — so the pod always lands on the same disk. If another node is ever
-      # given that label, in-flight downloads on the old node become orphaned
-      # and SAB will re-fetch them.
-      incomplete:
-        type: hostPath
-        hostPath: /var/mnt/sabnzbd-incomplete
-        hostPathType: DirectoryOrCreate
-        globalMounts:
-          - path: /incomplete
       media:
         type: custom
         volumeSpec:


### PR DESCRIPTION
**sabnzbd is down.** Stuck in `Init:0/1`, and the *arr report `downloadClientUnavailable`.

```
MountVolume.SetUp failed for volume "incomplete":
mkdir /var/mnt/sabnzbd-incomplete: read-only file system
```

## Why my earlier change didn't work

Talos gives kubelet a **restricted mount namespace**. A normal pod can write to `/var/mnt` — I verified with a probe pod on metal-07, where `/var`, `/var/lib` and `/var/mnt` all came back WRITABLE — but **kubelet itself cannot create directories there**, so `hostPathType: DirectoryOrCreate` fails.

This never surfaced when #1462 merged because sabnzbd couldn't roll at the time: its HelmRelease was blocked behind `volsync → rook-ceph-cluster` during the ceph-csi outage. It only rolled onto that config now, and failed immediately.

## This change

- `download_dir` back to the NFS path
- drops the hostPath volume and the chown initContainer that only existed to support it
- **keeps** `download_free: 100G` (a useful floor wherever incomplete/ lives)
- **keeps** `script_dir: /scripts` for the import-guard from #1489

## The performance case still stands

Recorded in a comment so it isn't lost. Measured with an 800 MiB `dd`, `iflag=direct` on reads, since par2 verify and unpack are read-heavy:

| storage | write | read |
|---|---|---|
| node-local | 1.7 GB/s | 1.7 GB/s |
| NFS | 91 MB/s | 38 MB/s |
| ceph-block | 48 MB/s | 18 MB/s |

Doing it properly needs `machine.kubelet.extraMounts` in `talos/machineconfig.yaml.j2` binding `/var/mnt` for kubelet, then a config apply to metal-07. Worth doing as its own change rather than while downloads are down.

`task validate` passes (171 flux-local tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)