### PR TITLE
fix(sabnzbd): put incomplete/ on /var/local-storage, not /var/mnt

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -26,6 +26,25 @@ spec:
       sabnzbd:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # hostPath dirs are created 0755 root:root by kubelet and fsGroup does
+          # not apply to hostPath volumes, so the app (uid 1031) cannot write to
+          # the mount without this chown.
+          init-incomplete:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                mkdir -p /incomplete
+                chown 1031:65536 /incomplete
+                chmod 0775 /incomplete
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
@@ -34,32 +53,19 @@ spec:
             env:
               TZ: America/Chicago
               SABNZBD__PORT: &port 80
-              # NOTE: incomplete/ is back on NFS. Moving it to a node-local
-              # hostPath is a real win — measured on this cluster with an 800MiB
-              # dd (iflag=direct on reads), since par2 verify and unpack are
-              # read-heavy:
+              # Incomplete downloads live on node-local disk instead of NFS.
+              # Measured on this cluster (800MiB dd, iflag=direct for reads):
               #   node-local  1.7 GB/s write   1.7 GB/s read
               #   NFS          91 MB/s write    38 MB/s read
               #   ceph-block   48 MB/s write    18 MB/s read
-              # (ceph-block is network storage too and measured worse than NFS,
-              # so only node-local helps.)
-              #
-              # But hostPath does not work here as-is. Talos gives kubelet a
-              # restricted mount namespace, so it cannot create directories
-              # under /var/mnt even though the path is writable from a normal
-              # pod:
-              #   MountVolume.SetUp failed for volume "incomplete":
-              #   mkdir /var/mnt/sabnzbd-incomplete: read-only file system
-              # That left sabnzbd stuck in Init:0/1 and the *arr reporting
-              # downloadClientUnavailable.
-              #
-              # Doing this properly needs machine.kubelet.extraMounts in
-              # talos/machineconfig.yaml.j2 binding /var/mnt for kubelet, then a
-              # config apply to metal-07. Worth doing as its own change.
-              SABNZBD__DOWNLOAD_DIR: /media/Downloads/sabnzbd/incomplete
-              # Kept regardless of where incomplete/ lives: without a floor a
-              # large queue can fill the volume. SAB pauses below this and
-              # fulldisk_autoresume=1 resumes automatically.
+              # par2 verify and unpack are read-heavy, so the 38 MB/s NFS read
+              # was the bottleneck. ceph-block is network storage too and
+              # measured worse than NFS, so only node-local helps here.
+              SABNZBD__DOWNLOAD_DIR: /incomplete
+              # /incomplete is on the node EPHEMERAL partition, shared with
+              # container storage. Without a guard a large queue can fill it and
+              # trigger disk-pressure eviction on metal-07. SAB pauses below this
+              # and fulldisk_autoresume=1 resumes automatically.
               SABNZBD__DOWNLOAD_FREE: 100G
               # Where SABnzbd looks for post-processing scripts. The script
               # itself still has to be selected per category in Config →
@@ -163,6 +169,27 @@ spec:
         defaultMode: 493
         globalMounts:
           - path: /scripts
+      # Node-local scratch for in-flight downloads. Safe as a hostPath because
+      # the nodeAffinity below pins this pod to nodes labelled
+      # node-role.kubernetes.io/media=true, and metal-07 is currently the only
+      # one — so the pod always lands on the same disk. If another node is ever
+      # given that label, in-flight downloads on the old node become orphaned
+      # and SAB will re-fetch them.
+      #
+      # MUST be under /var/local-storage. Talos gives kubelet a restricted mount
+      # namespace: /var/local-storage is a built-in writable path, but /var/mnt
+      # is reserved for declared user disks and kubelet cannot create
+      # directories there, so DirectoryOrCreate fails with
+      # "mkdir /var/mnt/...: read-only file system" and the pod hangs in Init.
+      # Confusingly a normal pod CAN write to /var/mnt — only kubelet cannot.
+      # This is the same path the old OpenEBS localpv used (3d83edb6), and it
+      # needs no machine.kubelet.extraMounts and no local CSI provisioner.
+      incomplete:
+        type: hostPath
+        hostPath: /var/local-storage/sabnzbd-incomplete
+        hostPathType: DirectoryOrCreate
+        globalMounts:
+          - path: /incomplete
       media:
         type: custom
         volumeSpec:

--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -26,25 +26,6 @@ spec:
       sabnzbd:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          # hostPath dirs are created 0755 root:root by kubelet and fsGroup does
-          # not apply to hostPath volumes, so the app (uid 1031) cannot write to
-          # the mount without this chown.
-          init-incomplete:
-            image:
-              repository: docker.io/library/busybox
-              tag: 1.38.0
-            command: ["/bin/sh", "-c"]
-            args:
-              - |
-                mkdir -p /incomplete
-                chown 1031:65536 /incomplete
-                chmod 0775 /incomplete
-            securityContext:
-              runAsUser: 0
-              runAsNonRoot: false
-              allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
@@ -53,19 +34,32 @@ spec:
             env:
               TZ: America/Chicago
               SABNZBD__PORT: &port 80
-              # Incomplete downloads live on node-local disk instead of NFS.
-              # Measured on this cluster (800MiB dd, iflag=direct for reads):
+              # NOTE: incomplete/ is back on NFS. Moving it to a node-local
+              # hostPath is a real win — measured on this cluster with an 800MiB
+              # dd (iflag=direct on reads), since par2 verify and unpack are
+              # read-heavy:
               #   node-local  1.7 GB/s write   1.7 GB/s read
               #   NFS          91 MB/s write    38 MB/s read
               #   ceph-block   48 MB/s write    18 MB/s read
-              # par2 verify and unpack are read-heavy, so the 38 MB/s NFS read
-              # was the bottleneck. ceph-block is network storage too and
-              # measured worse than NFS, so only node-local helps here.
-              SABNZBD__DOWNLOAD_DIR: /incomplete
-              # /incomplete is on the node EPHEMERAL partition, shared with
-              # container storage. Without a guard a large queue can fill it and
-              # trigger disk-pressure eviction on metal-07. SAB pauses below this
-              # and fulldisk_autoresume=1 resumes automatically.
+              # (ceph-block is network storage too and measured worse than NFS,
+              # so only node-local helps.)
+              #
+              # But hostPath does not work here as-is. Talos gives kubelet a
+              # restricted mount namespace, so it cannot create directories
+              # under /var/mnt even though the path is writable from a normal
+              # pod:
+              #   MountVolume.SetUp failed for volume "incomplete":
+              #   mkdir /var/mnt/sabnzbd-incomplete: read-only file system
+              # That left sabnzbd stuck in Init:0/1 and the *arr reporting
+              # downloadClientUnavailable.
+              #
+              # Doing this properly needs machine.kubelet.extraMounts in
+              # talos/machineconfig.yaml.j2 binding /var/mnt for kubelet, then a
+              # config apply to metal-07. Worth doing as its own change.
+              SABNZBD__DOWNLOAD_DIR: /media/Downloads/sabnzbd/incomplete
+              # Kept regardless of where incomplete/ lives: without a floor a
+              # large queue can fill the volume. SAB pauses below this and
+              # fulldisk_autoresume=1 resumes automatically.
               SABNZBD__DOWNLOAD_FREE: 100G
               # Where SABnzbd looks for post-processing scripts. The script
               # itself still has to be selected per category in Config →
@@ -169,18 +163,6 @@ spec:
         defaultMode: 493
         globalMounts:
           - path: /scripts
-      # Node-local scratch for in-flight downloads. Safe as a hostPath because
-      # the nodeAffinity below pins this pod to nodes labelled
-      # node-role.kubernetes.io/media=true, and metal-07 is currently the only
-      # one — so the pod always lands on the same disk. If another node is ever
-      # given that label, in-flight downloads on the old node become orphaned
-      # and SAB will re-fetch them.
-      incomplete:
-        type: hostPath
-        hostPath: /var/mnt/sabnzbd-incomplete
-        hostPathType: DirectoryOrCreate
-        globalMounts:
-          - path: /incomplete
       media:
         type: custom
         volumeSpec:


### PR DESCRIPTION
**sabnzbd is down** — stuck in `Init:0/1`, *arr reporting `downloadClientUnavailable`. This fixes it while keeping the node-local performance win.

Supersedes #1491, which fell back to NFS.

## The problem was the path, not the approach

```
MountVolume.SetUp failed for volume "incomplete":
mkdir /var/mnt/sabnzbd-incomplete: read-only file system
```

Talos gives kubelet a **restricted mount namespace**:

| path | kubelet can `mkdir`? |
|---|---|
| `/var/local-storage` | ✅ built-in writable |
| `/var/mnt` | ❌ reserved for declared user disks |

Confusingly, a **normal pod can write to `/var/mnt`** — I probed metal-07 and `/var`, `/var/lib` and `/var/mnt` all came back writable. Only kubelet is restricted, which is why this failed at mount time rather than anywhere earlier.

## Neither extraMounts nor a CSI provisioner needed

`/var/local-storage` is exactly what the old OpenEBS localpv used before it was removed — commit `3d83edb6`, *"use /var/local-storage which is already built-in"*.

Proved with a `DirectoryOrCreate` probe pod on metal-07:

```
phase: Succeeded
drwxr-xr-x 2 root root 6 Aug 6 12:02 /ls
KUBELET-CREATED-AND-WRITABLE
```

So no `machine.kubelet.extraMounts`, no Talos config apply, no local CSI driver — just the correct built-in path.

## Keeps the measured win

From #1462, with an 800 MiB `dd` and `iflag=direct` on reads (par2 verify and unpack are read-heavy):

| storage | write | read |
|---|---|---|
| node-local | **1.7 GB/s** | **1.7 GB/s** |
| NFS | 91 MB/s | 38 MB/s |
| ceph-block | 48 MB/s | 18 MB/s |

## Why it only broke now

#1462 merged earlier but sabnzbd couldn't roll — its HelmRelease was blocked behind `volsync → rook-ceph-cluster` during the ceph-csi outage. It rolled onto that config for the first time tonight and failed immediately. I verified the rendering when writing #1462 but had no way to exercise the actual mount.

`task validate` passes.

## After merge

sabnzbd should reach `Running 1/1`, and the Independence Day grab (48.9 GB, currently `downloadClientUnavailable`) resumes. Still outstanding: selecting `import-guard.py` for the **tv** and **movies** categories in SAB's Config → Categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)