### PR TITLE
fix(sabnzbd): set download_dir, download_free and script_dir via initContainer

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -45,6 +45,43 @@ spec:
               runAsNonRoot: false
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }
+          # The sabnzbd image only maps a fixed allowlist of env vars into the
+          # ini — api_key, nzb_key, port, address, host_whitelist_entries and
+          # local_ranges_entries. There is no generic SABNZBD__* mapping, so
+          # anything else set as an env var is silently ignored: it appears in
+          # the pod spec, never reaches sabnzbd.ini, and nothing warns.
+          #
+          # That is how download_dir stayed on NFS, download_free stayed empty
+          # (no disk-full guard) and script_dir stayed empty (the import-guard
+          # post-processing script never ran) even though all three were set as
+          # env vars.
+          #
+          # These keys already exist in [misc], so this rewrites them in place
+          # rather than appending. Runs as uid 1031 (inherited) which owns
+          # /config. Idempotent, and a no-op on first boot before the ini exists.
+          init-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                INI=/config/sabnzbd.ini
+                [ -f "$INI" ] || { echo "no ini yet, entrypoint will seed it"; exit 0; }
+                set_ini() {
+                  if grep -qE "^$1 = " "$INI"; then
+                    sed -i "s|^$1 = .*|$1 = $2|" "$INI"
+                    echo "set $1 = $2"
+                  else
+                    echo "WARNING: key $1 not found in $INI — not adding it"
+                  fi
+                }
+                set_ini download_dir /incomplete
+                set_ini download_free 100G
+                set_ini script_dir /scripts
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
         containers:
           app:
             image:
@@ -53,25 +90,17 @@ spec:
             env:
               TZ: America/Chicago
               SABNZBD__PORT: &port 80
-              # Incomplete downloads live on node-local disk instead of NFS.
-              # Measured on this cluster (800MiB dd, iflag=direct for reads):
+              # NOTE: download_dir, download_free and script_dir are NOT set
+              # here — this image ignores env vars outside its small allowlist.
+              # They are applied to sabnzbd.ini by the init-config initContainer
+              # above. See that comment for the full explanation.
+              #
+              # incomplete/ lives on node-local disk. Measured on this cluster
+              # with an 800MiB dd (iflag=direct on reads), which is what matters
+              # because par2 verify and unpack are read-heavy:
               #   node-local  1.7 GB/s write   1.7 GB/s read
               #   NFS          91 MB/s write    38 MB/s read
               #   ceph-block   48 MB/s write    18 MB/s read
-              # par2 verify and unpack are read-heavy, so the 38 MB/s NFS read
-              # was the bottleneck. ceph-block is network storage too and
-              # measured worse than NFS, so only node-local helps here.
-              SABNZBD__DOWNLOAD_DIR: /incomplete
-              # /incomplete is on the node EPHEMERAL partition, shared with
-              # container storage. Without a guard a large queue can fill it and
-              # trigger disk-pressure eviction on metal-07. SAB pauses below this
-              # and fulldisk_autoresume=1 resumes automatically.
-              SABNZBD__DOWNLOAD_FREE: 100G
-              # Where SABnzbd looks for post-processing scripts. The script
-              # itself still has to be selected per category in Config →
-              # Categories (tv, movies) — SABnzbd stores that in the
-              # [categories] ini section, which has no env-var equivalent.
-              SABNZBD__SCRIPT_DIR: /scripts
               SABNZBD__HOST_WHITELIST_ENTRIES: >-
                 sabnzbd,
                 sabnzbd.default,


### PR DESCRIPTION
## Three settings were silently doing nothing

The sabnzbd image maps only a **fixed allowlist** of env vars into `sabnzbd.ini`:

```
SABNZBD__ADDRESS   SABNZBD__API_KEY   SABNZBD__HOST_WHITELIST_ENTRIES
SABNZBD__LOCAL_RANGES_ENTRIES   SABNZBD__NZB_KEY   SABNZBD__PORT
```

There's no generic `SABNZBD__*` mapping — the entrypoint applies that list with `sed`. Anything else appears in the pod spec, never reaches the ini, and **nothing warns**.

I assumed the pattern generalised because `SABNZBD__PORT` worked. It doesn't.

| setting | believed | actual |
|---|---|---|
| `download_dir` | `/incomplete` | `/media/Downloads/sabnzbd/incomplete` — the node-local hostPath from #1462 was mounted but **unused** |
| `download_free` | `100G` | `""` — the disk-full guard **never existed** |
| `script_dir` | `/scripts` | `""` — the import-guard from #1489 was mounted but **never ran** |

## The fix

An `init-config` initContainer that rewrites the three keys in place. They already exist under `[misc]`, so it edits rather than appends, warns instead of guessing if a key is missing, and no-ops on first boot before the ini exists. Runs as uid 1031 (inherited), which owns `/config` — no root needed.

Also drops the three inert env vars and leaves a comment pointing at the initContainer, so they don't get re-added.

## Verified, not assumed

- **Rendered app-template 5.0.1** — `init-config` gets `/config` mounted and inherits `runAsUser: 1031`
- **Ran the sed against a copy of the live `sabnzbd.ini`**:

```
before:  download_dir = /media/Downloads/sabnzbd/incomplete
         download_free = ""
         script_dir = ""
after:   download_dir = /incomplete
         download_free = 100G
         script_dir = /scripts
```

## Merge timing matters

There is currently **126 GB of in-flight downloads under the NFS path**:

```
Independence.Day.1996.Repack.Extended.Cut...REMUX-FraMeSToR
Minions.The.Rise.of.Gru.2022.REPACK...playBD
Zootopia.2.2025...REMUX...ADDICTION
```

Switching `download_dir` mid-flight orphans those and re-downloads all 126 GB. **Let the queue drain first** (1 active, 9.1 GB left when checked), then merge.

Those three are all REMUX rather than disc rips, which is #1487 + #1488 working as intended.

## After merge

```bash
kubectl exec -n default <sab-pod> -c app -- grep -E '^(download_dir|download_free|script_dir) ' /config/sabnzbd.ini
```

Then select `import-guard.py` for the **tv** and **movies** categories in Config → Categories — that part still has no env-var equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)