### PR TITLE
fix(sabnzbd): relax liveness probe and extend termination grace period

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -122,8 +122,30 @@ spec:
             envFrom:
               - secretRef:
                   name: sabnzbd-secret
+            # SABnzbd serves its API from the same process that runs par2 repair
+            # and unpack, so the HTTP interface stalls under heavy jobs. The old
+            # settings (timeoutSeconds 1, failureThreshold 3, periodSeconds 10)
+            # treated 30s of slow responses as a dead container.
+            #
+            # On 2026-08-06 that fired during a 40-minute par2 repair of a 55 GB
+            # season pack on NFS. kubelet SIGTERMed the container twice; SABnzbd
+            # could not finish flushing its admin files inside the 30s grace
+            # period and was SIGKILLed (exit 137), truncating
+            # /config/admin/postproc2.sab:
+            #
+            #   Loading /config/admin/postproc2.sab failed
+            #   EOFError: Ran out of input
+            #
+            # That lost the post-processing queue and the entire history, which
+            # stranded 41 finished jobs in complete/ as _UNPACK_* folders the
+            # *arr never imported.
+            #
+            # Liveness now tolerates 3 minutes of unresponsiveness before
+            # restarting. Readiness stays tighter so a genuinely wedged instance
+            # still drops out of the Service, but not so tight that a normal
+            # repair takes the web UI offline.
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
@@ -131,10 +153,20 @@ spec:
                     path: /api?mode=version
                     port: *port
                   initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api?mode=version
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 15
+                  timeoutSeconds: 10
+                  failureThreshold: 4
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -146,6 +178,11 @@ spec:
               limits:
                 memory: 8Gi
     defaultPodOptions:
+      # SABnzbd writes its queue, history and post-processing state to
+      # /config/admin on shutdown. The default 30s was not enough while a repair
+      # was in flight — it was SIGKILLed mid-write and postproc2.sab was left
+      # truncated. See the probes comment above for the full incident.
+      terminationGracePeriodSeconds: 120
       securityContext:
         runAsNonRoot: true
         runAsUser: 1031


### PR DESCRIPTION
## Problem

SABnzbd was restarted twice on 2026-08-06 (exit 137) while 40 minutes into a par2 repair of a 55 GB season pack on NFS.

```
13:11:13 [newsunpack:1285] Repaired in 39 mins 55 seconds
13:16:32 [__init__:206]    Signal 15 caught, saving and exiting...
13:17:22 [__init__:206]    Signal 15 caught, saving and exiting...
13:17:55 [filesystem:1139] Loading /config/admin/postproc2.sab failed
                           EOFError: Ran out of input
```

SABnzbd serves its API from the same process that runs repair and unpack, so the HTTP interface stalls under load. The probe allowed only 30s of slow responses (`timeoutSeconds: 1`, `failureThreshold: 3`, `periodSeconds: 10`) before kubelet killed the container.

It then could not flush `/config/admin` inside the default 30s grace period and was SIGKILLed mid-write, truncating `postproc2.sab`.

Not memory: the container sits at ~154Mi against an 8Gi limit, and an OOM kill would not have sent SIGTERM first.

## Impact

Losing `postproc2.sab` dropped the post-processing queue and the entire history (`noofslots: 1` afterwards). 41 jobs finished unpacking but never got the post-processing rename, so they are stranded in `complete/` as `_UNPACK_*` folders — 71 GB — and the *arr never received completion callbacks. 40 of them hold finished MKVs with no rars remaining.

## Change

- Liveness: `periodSeconds` 10→30, `timeoutSeconds` 1→10, `failureThreshold` 3→6 — tolerates 3 minutes of unresponsiveness
- Readiness: split off the shared anchor, kept tighter (15s/10s/4) so a wedged instance still leaves the Service without a normal repair taking the web UI offline
- `terminationGracePeriodSeconds: 120` so shutdown can finish writing admin state

## Validation

`task validate` passes — 171 flux-local tests, kubeconform, OPA 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8