### PR TITLE
feat(recyclarr): block DV Profile 5, boost DV/HDR on the 4K profiles

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -130,6 +130,34 @@ sonarr:
           - name: Web 720p
           - name: Any
           - name: Ultra-HD
+      # Dolby Vision Profile 5 carries no HDR10 base layer, so a player that
+      # cannot do full P5 passthrough has nothing to fall back to — the picture
+      # comes out magenta/green or refuses to play outright. TRaSH calls this
+      # "DV (w/o HDR fallback)". Profile 8 is the portable flavour: it keeps an
+      # HDR10 base layer, so it plays on the Shield and the Apple TV both.
+      #
+      # Blocked on every profile rather than just the ones watched on the Apple
+      # TV. Scoping an unwanted-release format to only some profiles is exactly
+      # how the LQ and BR-DISK gaps below happened, and P8 releases exist for
+      # essentially anything that ships DV — so rejecting P5 costs no Dolby
+      # Vision anywhere, it only requires the flavour that plays everywhere.
+      - trash_ids:
+          - 9b27ab6498ec0f31a3353992e19434ca  # DV (w/o HDR fallback)
+        assign_scores_to:
+          - name: Web 1080p
+          - name: Web 720p
+          - name: Any
+          - name: Ultra-HD
+      # Ultra-HD is the 4K profile watched on the Shield downstairs, which
+      # handles Dolby Vision natively. Boost DV and HDR there only — the other
+      # profiles are 1080p and below, where these formats are rare and scoring
+      # them would shuffle rankings for no viewing benefit.
+      - trash_ids:
+          - 7c3a61a9c6cb04f52f1544be6d44a026  # DV Boost
+          - 505d871304820ba7106b693be6fe4a9e  # HDR
+          - 0c4b99df9206d2cfac3c05ab897dd62a  # HDR10+ Boost
+        assign_scores_to:
+          - name: Ultra-HD
 
 radarr:
   radarr:
@@ -283,3 +311,48 @@ radarr:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
         assign_scores_to:
           - name: Any
+      # Dolby Vision Profile 5 carries no HDR10 base layer, so a player that
+      # cannot do full P5 passthrough has nothing to fall back to. TRaSH calls
+      # this "DV (w/o HDR fallback)".
+      #
+      # Found through Chip 'n Dale: Rescue Rangers (2022), which would not play
+      # on the Apple TV. ffprobe on the imported file:
+      #
+      #   dv_profile=5   dv_bl_signal_compatibility_id=0   el_present_flag=0
+      #   color_transfer=unknown   color_primaries=unknown
+      #
+      # compatibility_id=0 is the tell — the base layer is IPT-PQ-C2, not
+      # HDR10, which is also why the colour transfer and primaries come back
+      # unknown. There is no standard HDR signalling in the file at all.
+      #
+      # No HDR or DV custom format existed here before this, so every release
+      # scored 0 and Radarr chose on quality and size alone with nothing to
+      # express that P5 is unplayable on half the house's devices. That movie
+      # lives on Any, which holds ~1141 of ~1166 movies — the same profile the
+      # LQ and BR-DISK gaps above were found in.
+      #
+      # Profile 8 keeps an HDR10 base layer and plays on the Shield and the
+      # Apple TV both, and P8 releases exist for essentially anything shipping
+      # DV. So blocking P5 everywhere costs no Dolby Vision on the Shield; it
+      # only requires the flavour that plays everywhere.
+      - trash_ids:
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (w/o HDR fallback)
+        assign_scores_to:
+          - name: Any
+          - name: Ultra-HD
+          - name: HD - 720p/1080p
+      # Ultra-HD is the 4K profile watched on the Shield downstairs, which
+      # handles Dolby Vision and Dolby surround natively. Boost DV and HDR
+      # there only: Any spans ~1141 mostly-1080p movies, and scoring HDR across
+      # all of them is a far larger behaviour change than this needs — the same
+      # scope reasoning as the LQ block above.
+      #
+      # Dolby audio is already covered for this profile. TrueHD Atmos, DD+
+      # ATMOS, TrueHD and DTS X are scored on Ultra-HD by the first
+      # custom_formats block near the top of the radarr section.
+      - trash_ids:
+          - b337d6812e06c200ec9a2d3cfa9d20a7  # DV Boost
+          - 493b6d1dbec3c3364c59d7607f7e3405  # HDR
+          - caa37d0df9c348912df1fb1d88f9273a  # HDR10+ Boost
+        assign_scores_to:
+          - name: Ultra-HD

--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -122,8 +122,30 @@ spec:
             envFrom:
               - secretRef:
                   name: sabnzbd-secret
+            # SABnzbd serves its API from the same process that runs par2 repair
+            # and unpack, so the HTTP interface stalls under heavy jobs. The old
+            # settings (timeoutSeconds 1, failureThreshold 3, periodSeconds 10)
+            # treated 30s of slow responses as a dead container.
+            #
+            # On 2026-08-06 that fired during a 40-minute par2 repair of a 55 GB
+            # season pack on NFS. kubelet SIGTERMed the container twice; SABnzbd
+            # could not finish flushing its admin files inside the 30s grace
+            # period and was SIGKILLed (exit 137), truncating
+            # /config/admin/postproc2.sab:
+            #
+            #   Loading /config/admin/postproc2.sab failed
+            #   EOFError: Ran out of input
+            #
+            # That lost the post-processing queue and the entire history, which
+            # stranded 41 finished jobs in complete/ as _UNPACK_* folders the
+            # *arr never imported.
+            #
+            # Liveness now tolerates 3 minutes of unresponsiveness before
+            # restarting. Readiness stays tighter so a genuinely wedged instance
+            # still drops out of the Service, but not so tight that a normal
+            # repair takes the web UI offline.
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
@@ -131,10 +153,20 @@ spec:
                     path: /api?mode=version
                     port: *port
                   initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api?mode=version
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 15
+                  timeoutSeconds: 10
+                  failureThreshold: 4
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -146,6 +178,11 @@ spec:
               limits:
                 memory: 8Gi
     defaultPodOptions:
+      # SABnzbd writes its queue, history and post-processing state to
+      # /config/admin on shutdown. The default 30s was not enough while a repair
+      # was in flight — it was SIGKILLed mid-write and postproc2.sab was left
+      # truncated. See the probes comment above for the full incident.
+      terminationGracePeriodSeconds: 120
       securityContext:
         runAsNonRoot: true
         runAsUser: 1031


### PR DESCRIPTION
## Problem

Chip 'n Dale: Rescue Rangers (2022) would not play on the Apple TV. `ffprobe` on the imported file:

```
dv_profile=5
dv_bl_signal_compatibility_id=0
el_present_flag=0
color_transfer=unknown
color_primaries=unknown
```

`compatibility_id=0` is the tell — the base layer is IPT-PQ-C2, not HDR10, so there is no fallback. A player that cannot do full DV Profile 5 passthrough has nothing usable to fall back to and renders magenta/green or refuses. The `unknown` transfer and primaries are the same fact in the metadata: no standard HDR signalling in the file at all.

The config had **no HDR or DV custom format of any kind** — the only match for `dolby vision|DV|hdr10` was a comment. So every release scored 0 and Radarr picked on quality and size with nothing to express that P5 is unplayable on half the house's devices.

That movie sits on `Any`, which holds ~1141 of ~1166 movies — the same profile the LQ and BR-DISK gaps were found in.

## Change

Custom format IDs taken from the TRaSH-Guides repo rather than written from memory.

**Both Sonarr and Radarr** — `DV (w/o HDR fallback)` at the TRaSH default of -10000, on every profile the config manages. Scoping an unwanted-release format to only some profiles is exactly how the LQ and BR-DISK gaps happened, so this goes everywhere. Profile 8 keeps an HDR10 base layer and plays on the Shield and the Apple TV both, and P8 releases exist for essentially anything shipping DV — so this costs no Dolby Vision, it just requires the flavour that plays everywhere.

**Ultra-HD only** — `DV Boost`, `HDR`, `HDR10+ Boost`. That is the 4K profile watched on the Shield downstairs, which handles DV natively. Kept off `Any`, since scoring HDR across ~1141 mostly-1080p movies is a much larger behaviour change than this needs. Dolby audio is already scored on Ultra-HD by the existing audio block (TrueHD Atmos, DD+ ATMOS, TrueHD, DTS X).

## Validation

`task validate` passes. Separately verified with `yq` that all 8 new trash_ids parse and that every `assign_scores_to` target matches a profile that actually exists — checked against the live Sonarr and Radarr `qualityprofile` APIs, since a recyclarr config error is silent (8.7.0 reported `Complete` while applying nothing when `quality_profiles` was renamed to `assign_scores_to`).

## Note

This changes future grabs only. The existing Chip 'n Dale P5 file is unaffected and still needs replacing by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8