### PR TITLE
fix(sabnzbd): keep completed jobs in history so the *arr can import

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -90,6 +90,22 @@ spec:
                 set_ini download_dir /incomplete
                 set_ini download_free 100G
                 set_ini script_dir /scripts
+                # Sonarr and Radarr detect a finished download by polling
+                # SABnzbd's active history. "all-archive" moves every job to the
+                # archive the instant it completes, so the *arr never sees it
+                # finish and never imports it — the job just silently piles up
+                # in complete/. Sonarr flags this itself:
+                #
+                #   Download client SABnzbd is set to remove completed
+                #   downloads. This can result in downloads being removed from
+                #   your client before Sonarr can import them.
+                #
+                # Found on 2026-08-06 with 167 folders stacked up in complete/
+                # and zero imports for hours, while SABnzbd reported every one
+                # of them as completed successfully. This is also the most
+                # likely origin of the 41 _UNPACK_ orphans recovered earlier
+                # that day — they predate the crash that was first blamed.
+                set_ini history_retention_option all
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }


### PR DESCRIPTION
## Problem

Sonarr and Radarr detect a finished download by polling SABnzbd's **active** history. `history_retention_option` was set to `all-archive`, which moves every job to the archive the instant it completes — so the *arr never saw a completion and never imported anything. The job just silently accumulated in `complete/`.

Found with 167 folders stacked up in `complete/` and zero Sonarr imports for hours, while SABnzbd reported every one of them completed successfully. It became visible when Sons of Anarchy S06 vanished from history seconds after a successful par2 reconstruct.

Sonarr flags this itself:

> Download client SABnzbd is set to remove completed downloads. This can result in downloads being removed from your client before Sonarr can import them.

This is also the most likely origin of the 41 `_UNPACK_` orphans recovered earlier the same day. Those were initially attributed to the crash that truncated `postproc2.sab` (#1496), but that crash only explains the one-time loss of the in-flight post-processing queue. This setting explains the ongoing accumulation, and it predates the crash.

## Change

```
set_ini history_retention_option all
```

Applied through the `init-config` initContainer alongside `download_dir`, `download_free` and `script_dir` — this image only maps a small allowlist of env vars into the ini, so anything else set as an env var is silently ignored. The key already exists in `[misc]`, so `set_ini` rewrites it in place rather than appending.

Already applied live via the API and confirmed persisted to `sabnzbd.ini`; this makes it declarative so a fresh config PVC doesn't reintroduce it.

## Validation

`task validate` passes — kubeconform, flux-local, OPA 0 errors / 0 warnings.

## Follow-up (not in this PR)

Jobs that completed *before* the live fix were already archived, so the *arr cannot reconcile them on their own. Those folders in `complete/` need a manual `DownloadedEpisodesScan` per folder, the same recovery used for the earlier 41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8