### PR TITLE
fix(sabnzbd): guard the NFS share with complete_free

### DIFF
--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -106,6 +106,21 @@ spec:
                 # likely origin of the 41 _UNPACK_ orphans recovered earlier
                 # that day — they predate the crash that was first blamed.
                 set_ini history_retention_option all
+                # download_free guards /incomplete (node-local NVMe). Nothing
+                # guarded complete_dir, which is the NFS share — so SABnzbd
+                # would happily fill it to 100% and take down every other
+                # workload writing there.
+                #
+                # Found on 2026-08-06 with the share at 96% (1.5T free of 32T)
+                # while 195 GB of UHD REMUXes were queued, several 40-80 GB
+                # each. complete_free was empty; download_free 100G only ever
+                # protected the local disk, which had 344 GB free and was never
+                # the constraint.
+                #
+                # SABnzbd pauses rather than fills. Note this does not stop
+                # Sonarr/Radarr grabbing — they just queue behind a paused
+                # client, which is the intended failure mode.
+                set_ini complete_free 500G
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }


### PR DESCRIPTION
## Problem

`download_free` protects `/incomplete`, which lives on node-local NVMe. **Nothing guarded `complete_dir`** — the NFS share — so SABnzbd would fill it to 100% and take down every other workload writing there.

Found on 2026-08-06:

```
/media   32T   30T   1.5T   96% full
complete_free = ""          <- no guard
download_free = 100G        <- guards local NVMe, 344G free, never the constraint
```

195 GB of UHD REMUXes were queued at the time, several 40–80 GB each.

## Change

```
set_ini complete_free 500G
```

SABnzbd pauses instead of filling. Worth noting this does **not** stop Sonarr and Radarr from grabbing — they queue behind a paused client, which is the intended failure mode.

Applied through the `init-config` initContainer alongside `download_dir`, `download_free`, `script_dir` and `history_retention_option`, since this image ignores env vars outside its small allowlist.

Already set live via the API and confirmed persisted to `sabnzbd.ini`; this makes it survive a fresh config PVC — the same gap #1498 closed for history retention.

## Validation

`task validate` passes — kubeconform, flux-local, OPA 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8