### PR TITLE
feat(audiobookshelf): deploy ebook and audiobook server

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
@@ -1,0 +1,141 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: audiobookshelf
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/advplyr/audiobookshelf
+              tag: 2.19.0@sha256:46f36b2f533e30347ae6d1e35ede6dc805a8d82211e26c4eee1f8f99cc245d48
+            env:
+              TZ: America/Chicago
+              PORT: &port 80
+              # Audiobookshelf keeps its SQLite DB and server settings in
+              # /config, and cover art plus cached probe data in /metadata.
+              # Both are written constantly, so neither can live on the
+              # read-only root filesystem.
+              CONFIG_PATH: /config
+              METADATA_PATH: /metadata
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthcheck
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1035
+        runAsGroup: 65536
+        fsGroup: 65536
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [100]
+        seccompProfile: { type: RuntimeDefault }
+      tolerations:
+        - key: "workload-type"
+          operator: "Equal"
+          value: "media"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/media
+                    operator: In
+                    values:
+                      - "true"
+    service:
+      app:
+        controller: main
+        ports:
+          http:
+            port: *port
+    # No serviceMonitor: exportarr has no audiobookshelf module and the app
+    # exposes no Prometheus endpoint. Liveness is covered by the gatus/guarded
+    # component wired in ks.yaml.
+    route:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.56kbps.io
+          external-dns.alpha.kubernetes.io/is-public: "true"
+        hostnames: ["audiobookshelf.56kbps.io"]
+        parentRefs:
+          - name: external-gateway
+            namespace: network
+            sectionName: https-56kbps
+          - name: internal-gateway
+            namespace: network
+            sectionName: https-56kbps
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: audiobookshelf
+      # Cover art and cached audio-probe results. Regenerable, so it is a
+      # separate emptyDir rather than something volsync has to back up —
+      # audiobookshelf rebuilds it by rescanning the library.
+      metadata:
+        type: emptyDir
+        globalMounts:
+          - path: /metadata
+      tmp:
+        type: emptyDir
+      # Read-only: audiobookshelf only ever reads the library. Writes go to
+      # /config and /metadata, so mounting the share read-only means a bug or
+      # a misconfigured "delete" in the UI cannot touch the media itself.
+      media:
+        type: custom
+        volumeSpec:
+          nfs:
+            server: ${SECRET_NFS_SERVER}
+            path: ${SECRET_NFS_PATH_MEDIA}
+            mountOptions:
+              - nfsvers=4.1
+              - hard
+              - noatime
+              - rsize=131072
+              - wsize=131072
+        globalMounts:
+          - path: /media
+            readOnly: true

--- a/kubernetes/apps/default/audiobookshelf/app/httproute-outpost.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/httproute-outpost.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# Serves the Authentik login/callback flow on the app hostname, outside the
+# SecurityPolicy so the redirect is reachable unauthenticated.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: audiobookshelf-outpost
+  namespace: default
+spec:
+  parentRefs:
+    - name: external-gateway
+      namespace: network
+      sectionName: https-56kbps
+    - name: internal-gateway
+      namespace: network
+      sectionName: https-56kbps
+  hostnames:
+    - "audiobookshelf.56kbps.io"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io
+      backendRefs:
+        - name: ak-outpost-56kbps
+          namespace: security
+          port: 9000

--- a/kubernetes/apps/default/audiobookshelf/app/kustomization.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute-outpost.yaml
+  - ./securitypolicy.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/default/audiobookshelf/app/securitypolicy.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/securitypolicy.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# Authentik forward-auth (Envoy ext-auth), same pattern as the *arr apps.
+# x-forwarded-proto is forwarded so redirects come back as https
+# (goauthentik/authentik#19653).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: audiobookshelf
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: audiobookshelf
+  extAuth:
+    failOpen: false
+    recomputeRoute: true
+    headersToExtAuth:
+      - X-Forwarded-For
+      - X-Real-Ip
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - kind: Service
+          name: ak-outpost-56kbps
+          namespace: security
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend:
+        - Set-Cookie
+        - X-authentik-uid
+        - X-authentik-username
+        - X-authentik-name
+        - X-authentik-email
+        - X-authentik-groups
+        - X-authentik-entitlements

--- a/kubernetes/apps/default/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/default/audiobookshelf/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app audiobookshelf
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/default/audiobookshelf/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_DOMAIN: halfduplex.io
+      VOLSYNC_SCHEDULE: "31 0 * * *"
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1035"
+      VOLSYNC_GID: "65536"
+      VOLSYNC_FSGROUP: "65536"

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: default
 components:
   - ../../components/common
 resources:
+  - ./audiobookshelf/ks.yaml
   - ./bazarr/ks.yaml
 # - ./bsky-pds/ks.yaml
 # - ./cert-exporter/ks.yaml


### PR DESCRIPTION
## Why

Readarr can no longer manage the book library — its metadata backend is gone:

```
http=503  "Search for 'Tom Clancy' failed. Invalid response received from Goodreads."
HttpRequestException: Name does not resolve (api.bookinfo.club:443)
```

Readarr was discontinued upstream and the hosted metadata proxy went with it. Without author lookup it can't add an author, and it won't import a book for an author it doesn't track — which is why its library shows **0 authors** while `/media/Library/e-books` already holds content organised by author (Martin, Crichton, Clancy) from when it still worked.

## What this does

Audiobookshelf takes over the **library and serving** half. Acquisition stays manual through Prowlarr, which now has SABnzbd registered as a download client; all three indexers advertise `Books/Ebook`, `Books/Technical` and `Audio/Audiobook`.

## Why not LazyLibrarian

It's the closer functional replacement (acquisition *and* management), but the only maintained image is LinuxServer's, which runs as **root** under s6-overlay and needs a writable root filesystem. That would be the first root container in this cluster — every other workload runs non-root with `readOnlyRootFilesystem: true`, and there are currently zero LinuxServer images anywhere in the repo.

Worth noting the OPA rule wouldn't have caught it either. It only denies an **explicit** `runAsUser: 0`:

```rego
input.metadata.annotations["home-ops/allow-root"] != "true"
container.securityContext.runAsUser == 0
```

LSIO images run as root by *default* without setting that field, so they pass validation while still running as root. Audiobookshelf's official image has no such constraint, so the question is moot here — but that policy gap is worth closing separately.

## Manifest notes

- **`/media` is mounted read-only.** Audiobookshelf only reads the library; all writes go to `/config` and `/metadata`. A bad delete in the UI can't reach the media.
- **`/metadata` is an emptyDir.** Cover art and cached audio-probe results are regenerable by rescanning, so volsync doesn't need to carry them — only `/config` (SQLite DB + settings) is backed up.
- **No serviceMonitor.** exportarr has no audiobookshelf module and the app exposes no Prometheus endpoint; the `gatus/guarded` component in `ks.yaml` covers liveness instead.
- UID 1035 (next free in the 1024–1039 range), authentik forward-auth via SecurityPolicy + outpost route, matching the *arr apps.

## Validation

`task validate` passes — kubeconform, flux-local, OPA 0 errors / 0 warnings.

## Follow-up

Readarr is now dead weight and can be removed (`kubernetes/apps/default/readarr` plus its PVC) once you've confirmed Audiobookshelf sees the library. Not included here so this PR stays additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8