### PR TITLE
fix(audiobookshelf): drop invalid nfs mountOptions, serve at books.56kbps.io

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/target: external.56kbps.io
           external-dns.alpha.kubernetes.io/is-public: "true"
-        hostnames: ["audiobookshelf.56kbps.io"]
+        hostnames: ["books.56kbps.io"]
         parentRefs:
           - name: external-gateway
             namespace: network
@@ -124,18 +124,20 @@ spec:
       # Read-only: audiobookshelf only ever reads the library. Writes go to
       # /config and /metadata, so mounting the share read-only means a bug or
       # a misconfigured "delete" in the UI cannot touch the media itself.
+      # NOTE: no mountOptions here. It is not a field on a pod's inline NFS
+      # volume source (only on a PersistentVolume), so the API server drops it.
+      # 10 other HelmReleases in this repo declare it and it has never taken
+      # effect — those mounts run on kernel defaults. Newer server-side apply
+      # rejects it outright rather than ignoring it, which is what made this
+      # install fail:
+      #   .spec.template.spec.volumes[name="media"].nfs.mountOptions:
+      #   field not declared in schema
       media:
         type: custom
         volumeSpec:
           nfs:
             server: ${SECRET_NFS_SERVER}
             path: ${SECRET_NFS_PATH_MEDIA}
-            mountOptions:
-              - nfsvers=4.1
-              - hard
-              - noatime
-              - rsize=131072
-              - wsize=131072
         globalMounts:
           - path: /media
             readOnly: true

--- a/kubernetes/apps/default/audiobookshelf/app/httproute-outpost.yaml
+++ b/kubernetes/apps/default/audiobookshelf/app/httproute-outpost.yaml
@@ -16,7 +16,7 @@ spec:
       namespace: network
       sectionName: https-56kbps
   hostnames:
-    - "audiobookshelf.56kbps.io"
+    - "books.56kbps.io"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/network/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/configs/config.yaml
@@ -88,6 +88,10 @@ ingress:
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:
       originServerName: "readarr.56kbps.io"
+  - hostname: "books.56kbps.io"
+    service: https://external-gateway.network.svc.cluster.local:443
+    originRequest:
+      originServerName: "books.56kbps.io"
   - hostname: "sonarr.56kbps.io"
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:


### PR DESCRIPTION
## The 404

Audiobookshelf never started. The HelmRelease has been failing since install:

```
Helm install failed: server-side apply failed for object default/audiobookshelf
apps/v1, Kind=Deployment: .spec.template.spec.volumes[name="media"].nfs.mountOptions:
field not declared in schema
```

`mountOptions` is **not a field on a pod's inline NFS volume source** — it only exists on a PersistentVolume. I copied it from the other media apps when writing #1514.

## The wider finding

It has never worked on those apps either:

```
$ kubectl get deploy sabnzbd -o jsonpath='{...nfs.mountOptions}'
(empty)
```

**11 HelmReleases declare it** — jellyfin, plex, sonarr, radarr, lidarr, bazarr, sabnzbd, qbittorrent, romm, readarr, audiobookshelf — and the API server silently drops it every time. So none of those NFS mounts have `nfsvers=4.1`, `hard`, `noatime` or the rsize/wsize tuning; they run on kernel defaults.

Older installs tolerated the bogus field silently. Server-side apply now rejects it, which is why only the *new* install broke.

I've **not** touched the other 10 here — they work as-is, and editing them would restart every media pod. Worth a follow-up: either drop the dead config, or move those mounts to real PersistentVolumes where `mountOptions` actually applies. The second is the real fix if that tuning was intended.

## Also in this PR

- **Renamed** `audiobookshelf.56kbps.io` → `books.56kbps.io` (helmrelease route + outpost HTTPRoute)
- **Added the cloudflared tunnel ingress**, which #1514 omitted entirely. External traffic is Cloudflare Tunnel → cloudflared → gateway, so without an ingress rule the hostname 404s even with a healthy pod. That was a second, independent cause of the same symptom.

## Validation

`task validate` passes — kubeconform, flux-local, OPA 0 errors / 0 warnings.

## Still needed after merge

Authentik forward-auth needs an **application entry in Terraform** (`terraform/authentik/applications.tf`) alongside lidarr/prowlarr, then `terraform apply`. The SecurityPolicy points at the outpost, but the outpost won't recognise `books.56kbps.io` until that exists — expect an auth redirect loop or 403 until it's applied. Not included here since it's a separate root and needs your apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8