### PR TITLE
fix(authentik): attach audiobookshelf to outpost, restore lost config

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/default/audiobookshelf/ks.yaml
@@ -28,6 +28,10 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      # App is "audiobookshelf" but it is served at books.*, so the gatus
+      # endpoint must be told the real subdomain or it probes a host that
+      # does not exist.
+      GATUS_SUBDOMAIN: books
       GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "31 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -67,6 +67,16 @@ locals {
       group         = resource.authentik_group.network
       cookie_domain = "halfduplex.io"
     },
+    audiobookshelf = {
+      external_host = "https://books.56kbps.io"
+      icon_url      = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/audiobookshelf.png"
+      group         = resource.authentik_group.media
+      cookie_domain = "56kbps.io"
+      # Audiobookshelf's mobile and web clients authenticate against its own
+      # user database over these paths. Forward-auth must not intercept them
+      # or the apps cannot log in or stream.
+      skip_path_regex = "^/(api|login|status|healthcheck|hls|feed|public)([/?].*)?"
+    },
     homeassistant = {
       external_host = "https://hass.56kbps.io"
       icon_url      = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/home-assistant-alt.png"

--- a/terraform/authentik/outposts.tf
+++ b/terraform/authentik/outposts.tf
@@ -14,6 +14,7 @@ locals {
     tonumber(authentik_provider_proxy.main["sabnzbd"].id),
     tonumber(authentik_provider_proxy.main["tautulli"].id),
     tonumber(authentik_provider_proxy.main["qbittorrent"].id),
+    tonumber(authentik_provider_proxy.main["audiobookshelf"].id),
   ]
 
   # halfduplex outpost = BBS only (cookie domain halfduplex.io via authentik_host sso.halfduplex.io)


### PR DESCRIPTION
## The error

```json
{
  "Message": "no app for hostname",
  "Host": "books.56kbps.io",
  "Detail": "Check the outpost settings and make sure 'books.56kbps.io' is included."
}
```

Creating the Authentik **application** and **proxy provider** isn't enough — the provider must also be listed in `authentik_outpost.main.protocol_providers`, which is an explicit array in `outposts.tf`. `audiobookshelf` wasn't in it, so the outpost had no route for the hostname.

## The bigger problem this exposed

`applications.tf` and the `GATUS_SUBDOMAIN` fix **never reached main**. They were committed to the #1516 branch *after* that PR was already merged:

```
origin/fix/audiobookshelf-install:
  60336d77  feat(authentik): add audiobookshelf application, fix gatus subdomain   ← never merged
  26ceab22  fix(audiobookshelf): drop invalid nfs mountOptions...                  ← merged as #1516
```

#1516 merged only three Kubernetes files. The Authentik resources existed live purely because they were applied by hand, so Terraform saw them as orphans:

```
Plan: 0 to add, 4 to change, 3 to destroy
Error: Invalid index — authentik_provider_proxy.main is object with 15 attributes
```

A routine `terraform apply` from main would have **destroyed** the audiobookshelf provider, application and policy binding. This PR cherry-picks 60336d77 back so config matches reality.

## Applied

Both changes are already applied to the live cluster (targeted applies), and the outpost was restarted to pick up the new provider. Plan is now clean apart from pre-existing drift:

```
Plan: 0 to add, 4 to change, 0 to destroy
```

Those four are the `authentik_provider_oauth2` `redirect_uri_type -> null` updates on gatus/grafana/homarr/lubelog — a provider schema change unrelated to this work, deliberately left alone rather than pushed through four live SSO integrations as a side effect.

## Lesson

Pushing a commit to a branch after its PR has merged silently drops it. Worth checking `git log origin/<branch>` against main before deleting merged branches — the commit is still there, just orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8