### PR TITLE
fix(blocky,jellyfin): repair hagezi blocklist URLs and clear stale restic lock

### DIFF
--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -22,6 +22,10 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      # Bumped to clear a stale restic lock held since 2026-08-10 00:08 by a
+      # mover pod that died mid-run. Every subsequent backup failed with
+      # "repository is already locked by PID 32 ... lock was created 13h ago".
+      VOLSYNC_UNLOCK: "1"
       VOLSYNC_SCHEDULE: "6 0 * * *"
       VOLSYNC_CAPACITY: 10Gi
   prune: true

--- a/kubernetes/apps/network/dns-resolver/blocky/app/configs/config.yml
+++ b/kubernetes/apps/network/dns-resolver/blocky/app/configs/config.yml
@@ -21,8 +21,8 @@ blocking:
   # Deny lists (formerly blackLists)
   denylists:
     hagezi:
-      - https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt
-      - https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.medium.txt
+      - https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/pro.txt
+      - https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/tif.medium.txt
     adult:
   # Allow lists (formerly whiteLists)
   allowlists:


### PR DESCRIPTION
Two failures found while investigating a multi-app incident.

## blocky — internal DNS crashlooping (197 restarts / 10h)

```
ERROR list_cache: cannot open source: got status code 404
  source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt
ERROR list_cache: could not init denylist error=producer error(s): got status code 404
```

Both hagezi lists 404 on `raw.githubusercontent.com` — the `wildcard/` directory on the **main branch is now empty** upstream.

Ruled out the alternatives before changing anything:
- **Not rate limiting** — 53/60 GitHub API requests remaining
- **Not a network fault** — jsDelivr serves the identical paths in full

```
jsdelivr wildcard/pro.txt         200  4,518,483 bytes
jsdelivr wildcard/tif.medium.txt  200  7,854,638 bytes
```

jsDelivr's `@latest` resolves to the current **release tag** rather than the branch, where the files still exist. Switched both URLs there.

Blocky treats a failed denylist init as fatal, so internal DNS went down on every restart — worth knowing as a single point of failure driven by an external URL.

## jellyfin — volsync blocked 13h by a stale lock

```
unable to create lock in backend: repository is already locked by PID 32
  on volsync-src-jellyfin-r2-4vqrs
lock was created at 2026-08-10 00:08:26 (13h11m ago)
```

`jellyfin/ks.yaml` had no `VOLSYNC_UNLOCK`, so nothing could clear a lock left by a mover pod that died mid-run. The snapshot succeeded on every run — only the follow-on `forget` failed, so **retention hasn't run since**. Added `VOLSYNC_UNLOCK: "1"`.

## Not in this PR

Fixed live, no repo change needed:
- **radarr / lidarr** — stale RBD mappings (Ceph itself `HEALTH_OK`); scale-to-0 and back gave a clean detach. 704 and 695 restarts → 0.
- **recyclarr** — its `Permission denied` was a symptom of radarr being unreachable for 37h; a manual run now completes cleanly for both radarr and sonarr.

Still needs a decision: **plex** — `Preferences.xml` is 0 bytes, truncated 2026-08-08 15:52 during the I/O failures. Volsync backups since then likely contain the empty file, so it needs either a restore from an older restic snapshot or a regenerate-and-reclaim.

## Validation

`task validate` passes — kubeconform, flux-local, OPA 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8