### PR TITLE
fix: recover jellyfin backups, wizarr, dragonfly operator and grafana

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/rbac.yaml
+++ b/kubernetes/apps/database/dragonfly/app/rbac.yaml
@@ -3,6 +3,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dragonfly-operator
+# This ClusterRole is maintained by hand, so it does not move when the operator
+# image does. Renovate bumped the operator v1.1.11 -> v1.6.1 (#1391) and the new
+# version watches ConfigMaps and NetworkPolicies as well; without those grants
+# their informers never sync and the manager exits:
+#
+#   failed to list *v1.ConfigMap: configmaps is forbidden: User
+#   "system:serviceaccount:database:dragonfly-operator" cannot list resource
+#   "configmaps" in API group "" at the cluster scope
+#
+# controller-runtime treats a cache that cannot sync as fatal, so this presented
+# as a CrashLoopBackOff (182 restarts) rather than as degraded functionality.
+# Keep the resources here in step with the operator's EventSources — they are
+# logged as "Starting EventSource ... kind source: *v1.X" at startup.
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -11,7 +24,17 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "services"]
+    resources: ["pods", "services", "configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # PodDisruptionBudget is not a registered EventSource — the operator reads it
+  # through the cached client during reconcile, which lazily starts an informer
+  # on first access. It therefore only surfaced once the ConfigMap/NetworkPolicy
+  # grants above let the manager get far enough to reconcile at all.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,6 +6,23 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
   replicas: 4 # set to the number of nodes in the cluster
+  # Operator v1.6.x added this field, defaulting to TRUE, and it generates a
+  # NetworkPolicy whose only rule for the client port is:
+  #
+  #   ingress: [{from: [{podSelector: {}}], ports: [{port: 6379}]}]
+  #
+  # An empty podSelector with no namespaceSelector means "pods in THIS namespace"
+  # — so it silently blocks every cross-namespace client. authentik (security
+  # namespace) is a consumer here, so the generated policy locks it out. The
+  # policy also admits the admin port 9999 only from pods labelled
+  # control-plane=controller-manager, which our app-template-deployed operator is
+  # not, so the operator locked itself out too and reconciles failed with
+  #   failed to determine dataset load status: dial tcp ...:9999: i/o timeout
+  #
+  # Disabled deliberately. If this is ever re-enabled, the policy needs a
+  # namespaceSelector for each consuming namespace and a selector matching the
+  # operator's actual labels.
+  networkPolicyEnabled: false
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -25,6 +25,25 @@ spec:
       # Bumped to clear a stale restic lock held since 2026-08-10 00:08 by a
       # mover pod that died mid-run. Every subsequent backup failed with
       # "repository is already locked by PID 32 ... lock was created 13h ago".
+      #
+      # This did NOT work, and cannot: VOLSYNC_UNLOCK runs plain `restic
+      # unlock`, which only removes locks it can prove are dead. It cannot
+      # verify a PID belonging to a pod that no longer exists, so an orphaned
+      # lock from a dead mover survives it forever. volsync knows — the fix is
+      # sitting commented out in its own mover script (mover-restic/entry.sh):
+      #
+      #   #if ! "${RESTIC[@]}" unlock --remove-all 2>"$outfile"; then
+      #   if ! "${RESTIC[@]}" unlock 2>"$outfile"; then
+      #
+      # volsync also records status.restic.lastUnlocked, so once a given value
+      # has been consumed it never retries — bumping this again is a no-op
+      # against this class of lock.
+      #
+      # Cleared 2026-08-10 by running `restic unlock --remove-all` in a one-off
+      # pod using this app's volsync R2 secret. Note the backups themselves were
+      # always fine ("snapshot 8c7bac77 saved"); only the follow-on forget was
+      # blocked, so the visible symptom is retention never running and lastSync
+      # never advancing while the data is in fact safe.
       VOLSYNC_UNLOCK: "1"
       VOLSYNC_SCHEDULE: "6 0 * * *"
       VOLSYNC_CAPACITY: 10Gi

--- a/kubernetes/apps/default/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/wizarr/app/helmrelease.yaml
@@ -33,12 +33,21 @@ spec:
               tag: v2026.7.1
             env:
               TZ: America/Chicago
+            # Steady-state RSS measured 245Mi on 2026-08-10, against a 286.1Mi
+            # limit — roughly 40Mi of headroom, and the pod was OOMKilled
+            # (exit 137) shortly after start. Raised to 512Mi.
+            #
+            # The fractional 286.1Mi also rendered as "299997593600m", which
+            # made every kubectl operation on this deployment emit
+            #   Warning: spec.template.spec.containers[0].resources.limits[memory]:
+            #   fractional byte value "299997593600m" is invalid, must be an integer
+            # Memory limits should be whole binary units.
             resources:
               requests:
                 cpu: 200m
-                memory: 131Mi
+                memory: 256Mi
               limits:
-                memory: 286.1Mi
+                memory: 512Mi
     service:
       app:
         controller: *app

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -205,6 +205,20 @@ spec:
         enabled: true
         storageClassName: ceph-block
         size: 5Gi
+      # ceph-block is RWO, so the volume can only be attached to one node at a
+      # time. The chart defaults to RollingUpdate, which stands up the new pod
+      # before retiring the old one — and if the new pod lands on a different
+      # node it can never mount, while the old pod never terminates because the
+      # new one never becomes ready. That deadlocked a rollout for 12h on
+      # 2026-08-10: grafana-7f44855 Running on metal-02 held the attachment
+      # while grafana-567486b964 sat Pending on metal-04 at Init:0/1
+      # (init-chown-data never started).
+      #
+      # Recreate terminates the old pod, releases the attachment, then starts
+      # the new one. Costs a few seconds of downtime per upgrade, which is the
+      # right trade for a single-replica dashboard.
+      deploymentStrategy:
+        type: Recreate
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
Four unrelated production issues found and fixed while verifying #1525. Each commit is standalone and documents its own root cause in-tree.

## `docs(jellyfin)` — VOLSYNC_UNLOCK cannot clear an orphaned lock

The R2 backup stopped advancing on 2026-08-09. Backups were in fact succeeding (`snapshot 8c7bac77 saved`) — only the follow-on `forget` was blocked, by a lock held by mover pod `...-4vqrs`, which no longer exists.

Bumping `VOLSYNC_UNLOCK` did not fix it and **cannot**: it runs plain `restic unlock`, which only removes locks it can prove are dead, and it cannot verify a PID from a pod that is gone. volsync ships the real fix commented out in its own mover script:

```bash
#if ! "${RESTIC[@]}" unlock --remove-all 2>"$outfile"; then
if ! "${RESTIC[@]}" unlock 2>"$outfile"; then
```

Cleared out-of-band with `restic unlock --remove-all` (removed 2 locks); `lastSync` advanced `2026-08-09T00:15` → `2026-08-10T16:43`. Comment-only change so the next person doesn't repeat the bump. All 23 ReplicationSources checked — jellyfin was the only stale one.

## `fix(wizarr)` — memory limit below measured RSS

OOMKilled (exit 137). Steady-state RSS is 245Mi against a `286.1Mi` limit. Raised to 512Mi, requests 131Mi → 256Mi. The fractional limit also rendered as `299997593600m`, making every kubectl call against the deployment emit a `fractional byte value ... must be an integer` warning.

## `fix(dragonfly)` — operator RBAC + generated NetworkPolicy

Operator was in CrashLoopBackOff (182 restarts). Renovate bumped it v1.1.11 → v1.6.1 (#1391), but `rbac.yaml` is hand-maintained and still carried the v1.1.x resource set. The newer version watches ConfigMaps and NetworkPolicies; controller-runtime treats an informer that cannot sync as **fatal**, so it crashed rather than degrading. PodDisruptionBudget was also missing — it is not a registered EventSource, it is read lazily during reconcile, so it only surfaced once the first two grants let startup get that far.

Granting NetworkPolicy access then exposed a second problem: v1.6.x added `spec.networkPolicyEnabled` **defaulting to true**, and the generated policy's client-port rule is

```yaml
ingress:
  - from: [{podSelector: {}}]
    ports: [{port: 6379}]
```

An empty `podSelector` with no `namespaceSelector` means *this namespace only*, so every cross-namespace client is denied — and authentik (in `security`) is a consumer. It also admits admin port 9999 only from `control-plane=controller-manager`, which our app-template-deployed operator is not, so the operator locked itself out of its own instances. Disabled deliberately.

With the operator alive again it completed a rollout that had been stalled 21h; all four pods are now on v1.40.1 and the CR reads `Ready`.

## `fix(grafana)` — Recreate strategy for RWO-backed deployment

Stuck at `Init:0/1` for 12h. grafana persists to `ceph-block` (RWO, single-node attach) but the chart defaults to `RollingUpdate`, which starts the new pod before retiring the old one. The new pod landed on metal-04 while the old pod held the VolumeAttachment on metal-02, so it could never mount — and the old pod never terminated because the replacement never became ready. `Recreate` breaks the cycle.

Swept the cluster: **zero** other Deployments combine `RollingUpdate` with an RWO PVC.

## Verification

- jellyfin `lastSync` advanced; schedule restored (`6 0 * * *`)
- wizarr `1/1 Running`, at head revision `20260401_repair`, data intact
- dragonfly operator `1/1 Running`, **0** `forbidden` in logs; `PING` from `authentik-server` (security) → `dragonfly.database.svc:6379` returns `+PONG`
- grafana `3/3 Running`, `/api/health` → `database: ok`, attachment moved to metal-04
- `kustomize build` + all pre-commit hooks (kubeconform, JSON schema, gitleaks) pass

## Note on live state

The dragonfly RBAC/CR changes and the grafana strategy patch are already applied to the cluster and match this branch, so Flux converges on merge. The grafana one is Helm-owned, so a `kube-prometheus-stack` reconcile before merge would revert it and re-deadlock the next rollout — worth merging reasonably soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8