### PR TITLE
feat(database): shared postgres instance + restore postgresql component

### DIFF
--- a/kubernetes/apps/database/postgres/app/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/app/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: postgres-secret
+    template:
+      engineVersion: v2
+      data:
+        # Consumed by the postgres entrypoint on first boot to set the
+        # superuser password. Ignored on subsequent boots — the password then
+        # lives in the data directory, so changing this alone does NOT rotate
+        # it (that needs an ALTER ROLE).
+        POSTGRES_PASSWORD: "{{ .POSTGRES_SUPER_PASS }}"
+        # Same value, under the name libpq looks for. The nightly pg_dumpall
+        # CronJob connects over TCP and authenticates with this.
+        PGPASSWORD: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    # 1Password item is "postgresql" (not "postgres" — the app name here does
+    # not match the item title). A stale "cloudnative-pg" item also carries a
+    # POSTGRES_SUPER_PASS from the removed operator; this is deliberately not
+    # that one.
+    - extract:
+        key: postgresql

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -1,0 +1,184 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app postgres
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      # Shared instance. Every consuming app gets its own database and role
+      # inside it, created idempotently by the init-db initContainer that
+      # components/postgresql injects — not its own postgres.
+      postgres:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/library/postgres
+              tag: 18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+            env:
+              TZ: America/Chicago
+              POSTGRES_USER: postgres
+              POSTGRES_DB: postgres
+              # MUST be a subdirectory of the mount, not the mount root:
+              # initdb refuses to run in a non-empty directory and an
+              # RBD/ext4 volume always has lost+found at its root. Also note
+              # the 18 images changed the default to /var/lib/postgresql/18/
+              # docker, so leaving this unset would put the data somewhere
+              # that is not on the PVC at all.
+              PGDATA: /var/lib/postgresql/data/pgdata
+            envFrom:
+              - secretRef:
+                  name: postgres-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["pg_isready", "-U", "postgres", "-d", "postgres"]
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["pg_isready", "-U", "postgres", "-d", "postgres"]
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["pg_isready", "-U", "postgres", "-d", "postgres"]
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  # initdb on first boot, and WAL replay after an unclean stop,
+                  # are slow on ceph-block. 30 x 10s = 5 minutes before the
+                  # liveness probe is allowed to start killing the container.
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+
+      # Logical dumps, for the restore case the physical snapshot handles badly:
+      # "put lubelog's database back" without rolling the whole volume — and
+      # every other app on this instance — back with it.
+      dump:
+        type: cronjob
+        cronjob:
+          schedule: "15 0 * * *"
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 2
+        pod:
+          # Writes into the same RWO PVC postgres is using. RWO permits many
+          # pods on ONE node, so this must land on postgres's node or the mount
+          # fails. (ReadWriteOncePod would forbid this outright; RWO does not.)
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: postgres
+          restartPolicy: OnFailure
+        containers:
+          app:
+            image:
+              repository: docker.io/library/postgres
+              tag: 18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+            env:
+              TZ: America/Chicago
+            envFrom:
+              - secretRef:
+                  name: postgres-secret
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                set -eu
+                DIR=/var/lib/postgresql/data/dumps
+                mkdir -p "$DIR"
+                STAMP=$(date +%Y%m%d-%H%M%S)
+                OUT="$DIR/pg_dumpall-$STAMP.sql.gz"
+                # Write to .tmp then rename, so a dump interrupted midway never
+                # leaves a truncated file that looks like a usable backup.
+                pg_dumpall -h postgres.database.svc.cluster.local -U postgres \
+                  --clean --if-exists | gzip -9 > "$OUT.tmp"
+                mv "$OUT.tmp" "$OUT"
+                # Retain the 7 newest. volsync keeps 7 daily snapshots of this
+                # volume, so R2 holds roughly a week of dumps either way.
+                ls -1t "$DIR"/pg_dumpall-*.sql.gz | tail -n +8 | xargs -r rm -f
+                echo "wrote $OUT ($(stat -c %s "$OUT") bytes)"
+                echo "retained: $(ls -1 "$DIR"/pg_dumpall-*.sql.gz | wc -l) dump(s)"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /var/lib/postgresql/data
+      # readOnlyRootFilesystem means the unix socket directory and scratch
+      # space both have to be writable mounts.
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run/postgresql
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -2,10 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: database
-components:
-  - ../../components/common
 resources:
-  - ./dragonfly/ks.yaml
-  - ./mosquitto/ks.yaml
-  - ./postgres/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/postgres/ks.yaml
+++ b/kubernetes/apps/database/postgres/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app postgres
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/database/postgres/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # Deliberately wait: true. Apps consuming this run an init-db initContainer
+  # that connects on startup, so they must not reconcile until postgres is
+  # actually serving. The postgresql component makes them dependsOn this.
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: *app
+      # The official postgres images run as uid/gid 70, so the volsync mover
+      # has to match or it cannot read the data directory it is backing up.
+      VOLSYNC_UID: "70"
+      VOLSYNC_GID: "70"
+      VOLSYNC_FSGROUP: "70"
+      VOLSYNC_CAPACITY: 20Gi
+      # Runs after the 00:15 pg_dumpall so every snapshot carries a fresh
+      # logical dump alongside the physical data directory. copyMethod defaults
+      # to Snapshot, so the restic backup is taken from an atomic CSI snapshot
+      # rather than from files being written underneath it — which is what
+      # makes a physical postgres backup safe to restore.
+      VOLSYNC_SCHEDULE: "40 0 * * *"

--- a/kubernetes/components/postgresql/externalsecret.yaml
+++ b/kubernetes/components/postgresql/externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-db
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: ${APP}-db-secret
+    template:
+      engineVersion: v2
+      data:
+        # Per-app role and database, created idempotently by the init-db
+        # initContainer on every pod start. The app's own 1Password item
+        # supplies <APP>_POSTGRES_USER / _PASS.
+        INIT_POSTGRES_USER: '{{ index . (printf "%s_POSTGRES_USER" (upper "${APP}")) }}'
+        INIT_POSTGRES_PASS: '{{ index . (printf "%s_POSTGRES_PASS" (upper "${APP}")) }}'
+        # The single shared instance in the database namespace — NOT a
+        # per-app server. See kubernetes/apps/database/postgres.
+        INIT_POSTGRES_HOST: "postgres.database.svc.cluster.local"
+        INIT_POSTGRES_SUPER_PASS: '{{ .POSTGRES_SUPER_PASS }}'
+  dataFrom:
+    - extract:
+        key: ${APP}
+    # Superuser password, from the "postgresql" item — the same one the server
+    # itself reads. Note the item title is not "postgres".
+    - extract:
+        key: postgresql

--- a/kubernetes/components/postgresql/kustomization.yaml
+++ b/kubernetes/components/postgresql/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - externalsecret.yaml
+
+patches:
+  - target:
+      kind: HelmRelease
+    path: patches/helm-initContainers.yaml
+  - target:
+      kind: HelmRelease
+    path: patches/helm-dependencies.yaml
+  - target:
+      kind: Kustomization
+    path: patches/kustomization-dependencies.yaml

--- a/kubernetes/components/postgresql/patches/helm-dependencies.yaml
+++ b/kubernetes/components/postgresql/patches/helm-dependencies.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: required-for-kustomize-but-not-used
+spec:
+  dependsOn:
+    - name: postgres
+      namespace: database

--- a/kubernetes/components/postgresql/patches/helm-initContainers.yaml
+++ b/kubernetes/components/postgresql/patches/helm-initContainers.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: required-for-kustomize-but-not-used
+spec:
+  values:
+    controllers:
+      main:
+        initContainers:
+          # Creates this app's role and database on the shared instance if they
+          # do not already exist, then exits. Idempotent, so it runs on every
+          # pod start and is a no-op after the first.
+          #
+          # Image moved namespace: ghcr.io/onedr0p/postgres-init is abandoned
+          # (its last tag is 16), ghcr.io/home-operations/postgres-init is the
+          # maintained continuation. Keep the tag on the same major as the
+          # server in kubernetes/apps/database/postgres.
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: ${APP}-db-secret
+              - secretRef:
+                  name: ${APP}-secret

--- a/kubernetes/components/postgresql/patches/kustomization-dependencies.yaml
+++ b/kubernetes/components/postgresql/patches/kustomization-dependencies.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: required-for-kustomize-but-not-used
+spec:
+  dependsOn:
+    # The postgres Kustomization sets wait: true, so it only reports Ready once
+    # the server is actually accepting connections. That is what makes this
+    # dependency sufficient on its own — the old CNPG version of this component
+    # additionally needed a healthCheck on the Cluster CR, because Kustomization
+    # readiness there did not imply a usable database.
+    - name: postgres
+      namespace: database


### PR DESCRIPTION
Stands up a single shared Postgres and restores the per-app component that consumes it. This unblocks **homeassistant** and **lubelog**, both of which are commented out of `kubernetes/apps/default/kustomization.yaml` today purely because they reference a `components/postgresql` that no longer exists.

## Why not CNPG (again)

CNPG was removed from this repo previously (`feat(cloudnative-pg): remove cloudnative-pg`), and that removal took `components/postgresql` with it — which is what stranded both apps.

The architecture here is the same one the repo already had: the deleted component pointed every app at one shared `postgres16.database.svc.cluster.local` and used `postgres-init` to create that app's database and role. Only the backing cluster changes — an operator's `Cluster` CR becomes a plain StatefulSet.

The deciding argument is that this shape is already proven here: `security/authentik-postgresql` has run as a plain StatefulSet for 294 days without incident. Ceph already provides the durability an operator's failover would mostly duplicate — a node loss reattaches the RBD volume and restarts the pod. What's given up is automated failover and second-granular PITR; if that's ever wanted, CNPG with **one** shared `Cluster` plus `Database` CRDs is a dump-and-restore away, and nothing app-side changes because the DSN is identical.

## Layout

One instance, many databases — not one instance per app:

```
database/postgres  (StatefulSet, replicas: 1)
├── db: homeassistant   owner: homeassistant
├── db: lubelog         owner: lubelog
└── db: <next app>      owner: <next app>
```

`security/authentik-postgresql` deliberately stays separate: a Postgres incident that also takes out SSO would lock you out of every app behind Authentik while you fix it.

## Details worth reviewing

- **`PGDATA` is pinned to a subdirectory.** Checked against the image rather than assumed — the 18 images moved the default to `/var/lib/postgresql/18/docker`, which is not on the PVC. Left unset, the data would land on ephemeral container storage. It also cannot be the mount root: `initdb` refuses a non-empty directory and an RBD/ext4 volume always has `lost+found`.
- **uid/gid 70**, verified from the image. Not copied from authentik's, which is a Bitnami-flavoured chart running as 1001 with `PGDATA` under `/bitnami`. The volsync mover UID matches or it cannot read what it backs up.
- **Backups are two-layer.** volsync `copyMethod: Snapshot` means restic backs up an atomic CSI snapshot rather than files changing underneath it — that is what makes a *physical* postgres backup restorable. On top, a nightly `pg_dumpall` at 00:15 (ahead of the 00:40 volsync run) lands logical dumps on the same volume, so every R2 snapshot carries one. That covers the restore a physical snapshot handles badly: putting one app's database back without rolling every other app back with it.
- **The dump CronJob has podAffinity onto the postgres pod**, because it writes to the same RWO PVC. RWO permits many pods on one node but not across nodes.
- **`postgres-init` moved namespace**: `ghcr.io/onedr0p/postgres-init` is abandoned at tag 16, same as `onedr0p/home-assistant` at 2025.3.3. Now `ghcr.io/home-operations/postgres-init:18`, matching the server major.
- **Superuser password comes from the `postgresql` 1Password item** — note the title does not match the app name, and a stale `cloudnative-pg` item carries its own `POSTGRES_SUPER_PASS` from the removed operator. This is deliberately not that one.
- Dropped `patches/kustomization-healthcheck.yaml`: it existed because a Kustomization going Ready did not imply the CNPG `Cluster` was usable. The postgres Kustomization sets `wait: true`, so `dependsOn` alone now means the server accepts connections.

## Verification

- ExternalSecret resolves against the live 1Password store — `SecretSynced`, `POSTGRES_SUPER_PASS` present (throwaway preflight, since removed)
- Component built against lubelog: `init-db` initContainer and `dependsOn: postgres/database` both land correctly
- `kustomize build` on `apps/database` and `apps/database/postgres/app`
- `validate-schemas.sh` passes on the HelmRelease (app-template values are strict about the cronjob controller)
- All pre-commit hooks pass

## Not in this PR

homeassistant and lubelog stay commented out. Both need `<APP>_POSTGRES_USER`/`_PASS` added to their 1Password items, and homeassistant additionally needs its dangling `dependsOn: emqx-cluster` repointed at mosquitto and its image moved off the abandoned `onedr0p` namespace (2025.3.3 → 2026.8.1).

A restore rehearsal against this instance comes before any \*arr migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8