### PR TITLE
fix(postgres): dump per-database instead of one pg_dumpall archive

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -92,6 +92,10 @@ spec:
       # Logical dumps, for the restore case the physical snapshot handles badly:
       # "put lubelog's database back" without rolling the whole volume — and
       # every other app on this instance — back with it.
+      #
+      # Dumped per-database (plus globals) rather than as one pg_dumpall
+      # archive, because a pg_dumpall restores the entire cluster or nothing —
+      # which would defeat the only reason these dumps exist.
       dump:
         type: cronjob
         cronjob:
@@ -126,20 +130,37 @@ spec:
             args:
               - |
                 set -eu
+                HOST=postgres.database.svc.cluster.local
                 DIR=/var/lib/postgresql/data/dumps
-                mkdir -p "$DIR"
-                STAMP=$(date +%Y%m%d-%H%M%S)
-                OUT="$DIR/pg_dumpall-$STAMP.sql.gz"
-                # Write to .tmp then rename, so a dump interrupted midway never
-                # leaves a truncated file that looks like a usable backup.
-                pg_dumpall -h postgres.database.svc.cluster.local -U postgres \
-                  --clean --if-exists | gzip -9 > "$OUT.tmp"
-                mv "$OUT.tmp" "$OUT"
-                # Retain the 7 newest. volsync keeps 7 daily snapshots of this
-                # volume, so R2 holds roughly a week of dumps either way.
-                ls -1t "$DIR"/pg_dumpall-*.sql.gz | tail -n +8 | xargs -r rm -f
-                echo "wrote $OUT ($(stat -c %s "$OUT") bytes)"
-                echo "retained: $(ls -1 "$DIR"/pg_dumpall-*.sql.gz | wc -l) dump(s)"
+                DEST="$DIR/$(date +%Y%m%d-%H%M%S)"
+                mkdir -p "$DEST"
+
+                # Globals (roles, grants, tablespaces) are NOT included in a
+                # per-database dump, so they are captured separately.
+                pg_dumpall -h "$HOST" -U postgres --globals-only \
+                  | gzip -9 > "$DEST/globals.sql.gz.tmp"
+                mv "$DEST/globals.sql.gz.tmp" "$DEST/globals.sql.gz"
+
+                # One custom-format dump per database. This is the whole point:
+                # a single app can be put back with
+                #   pg_restore -h HOST -U postgres -d <db> --clean <db>.dump
+                # without replaying, and therefore rolling back, every other
+                # app sharing this instance. A pg_dumpall archive cannot do
+                # that — it restores the entire cluster or nothing.
+                for DB in $(psql -h "$HOST" -U postgres -tAc \
+                    "select datname from pg_database where not datistemplate and datallowconn order by 1"); do
+                  # -Fc writes to a file directly, so write to .tmp and rename:
+                  # an interrupted dump must never look like a usable backup.
+                  pg_dump -h "$HOST" -U postgres -Fc -d "$DB" -f "$DEST/$DB.dump.tmp"
+                  mv "$DEST/$DB.dump.tmp" "$DEST/$DB.dump"
+                  echo "  $DB -> $(stat -c %s "$DEST/$DB.dump") bytes"
+                done
+
+                # Retain 7 dated directories. volsync keeps 7 daily snapshots of
+                # this volume, so R2 holds roughly a week either way.
+                ls -1d "$DIR"/*/ 2>/dev/null | sort -r | tail -n +8 | xargs -r rm -rf
+                echo "wrote $DEST"
+                echo "retained: $(ls -1d "$DIR"/*/ 2>/dev/null | wc -l) dump set(s)"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Found by running the restore rehearsal against the instance deployed in #1533, before pointing any app at it.

## The problem

The dump CronJob wrote a single `pg_dumpall` archive. That is a **whole-cluster** dump — restoring it replays every database. So "put lubelog's database back" would have rolled homeassistant, and eventually every \*arr, back to the same timestamp.

That is the only reason these logical dumps exist alongside the volsync snapshot, so the job was not delivering its purpose. With just a scratch database on the instance it looked like it worked, which is exactly why this would have gone unnoticed until the day it mattered.

## The fix

Each run now writes a timestamped directory containing:

- `globals.sql.gz` — roles, grants, tablespaces. Not captured by per-database dumps, so taken separately.
- `<db>.dump` — one custom-format `pg_dump` per database.

Restoring a single app becomes:

```
pg_restore -h postgres.database.svc.cluster.local -U postgres -d <db> <db>.dump
```

Retention is unchanged at 7 sets, still landing on the volsync-backed volume ahead of the 00:40 snapshot.

## Rehearsal

Two scratch databases. Dump taken, then `drill` dropped **and `drill2` modified after the dump**, then `drill` alone restored:

```
drill restored:    500 rows, checksum 9511b206a9a3c995e660997130e48574   ← matches pre-drop
drill2 untouched:  MODIFIED-after-dump                                    ← not reverted
```

`drill2` retaining its post-dump modification is the assertion that matters — under the old script it would have been rolled back to `original-state`.

Also measured on the way through:

| | old (`pg_dumpall`) | new (per-db) |
|---|---|---|
| restore time | 51s | **8s** |
| restore errors | 2 | **0** |
| blast radius | whole cluster | one database |

The 2 old errors were benign — the `current user cannot be dropped` / `role "postgres" already exists` pair that `pg_dumpall --clean` always emits — but they are gone now regardless.

Scratch databases and test dumps were cleaned up; the instance is back to `postgres` / `template0` / `template1` with an empty dumps directory.

## Verification

- `validate-schemas.sh` and `kustomize build` pass
- Script executed end to end against the live instance (per-database dumps produced for `drill`, `drill2`, `postgres`)
- All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8