### PR TITLE
feat(adminer): web admin UI for the shared postgres, behind Authentik

### DIFF
--- a/kubernetes/apps/database/adminer/app/helmrelease.yaml
+++ b/kubernetes/apps/database/adminer/app/helmrelease.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app adminer
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: postgres
+      namespace: database
+  values:
+    controllers:
+      adminer:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Adminer's entrypoint writes into its own docroot: it symlinks the
+          # chosen design to ./adminer.css and generates a loader per plugin
+          # into plugins-enabled/. With readOnlyRootFilesystem those writes fail
+          # and, because the entrypoint runs under `set -e`, the container exits
+          # rather than degrading.
+          #
+          # Seeding the docroot into an emptyDir keeps the root filesystem
+          # read-only while giving the entrypoint somewhere writable. Mounting
+          # the emptyDir straight onto /var/www/html without this would hide
+          # adminer.php and the bundled designs.
+          init-html:
+            image:
+              repository: docker.io/library/adminer
+              tag: 5.5.1-standalone@sha256:890cffec7caa20159fb6f68c1a521b2e5879f7314f4845d4ebca7cc1cf145971
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                cp -a /var/www/html/. /html/
+                echo "seeded docroot: $(ls -1 /html | wc -l) entries"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+        containers:
+          app:
+            image:
+              repository: docker.io/library/adminer
+              tag: 5.5.1-standalone@sha256:890cffec7caa20159fb6f68c1a521b2e5879f7314f4845d4ebca7cc1cf145971
+            env:
+              TZ: America/Chicago
+              # Prefills the Server field so only credentials are typed.
+              ADMINER_DEFAULT_SERVER: postgres.database.svc.cluster.local
+              ADMINER_DESIGN: pepa-linha
+              # Space-separated; the entrypoint turns each into a loader in
+              # plugins-enabled/. login-reverse-proxy is NOT authentication —
+              # it keys brute-force throttling off X-Forwarded-For so failed
+              # attempts are not all attributed to the Envoy gateway's IP.
+              ADMINER_PLUGINS: >-
+                tables-filter
+                edit-textarea
+                pretty-json-column
+                dump-json
+                sql-log
+                highlight-codemirror
+                login-reverse-proxy
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: adminer
+        ports:
+          http:
+            port: 8080
+    route:
+      app:
+        # Internal gateway only, deliberately. This is direct database access;
+        # it has no business being reachable from the Cloudflare tunnel even
+        # with forward-auth in front of it.
+        hostnames: ["postgres.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+            sectionName: https-56kbps
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
+    persistence:
+      html:
+        type: emptyDir
+        advancedMounts:
+          adminer:
+            init-html:
+              - path: /html
+            app:
+              - path: /var/www/html
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/database/adminer/app/httproute-outpost.yaml
+++ b/kubernetes/apps/database/adminer/app/httproute-outpost.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# The Authentik login flow itself is served under /outpost.goauthentik.io on the
+# app's own hostname, so it has to bypass the app backend and go straight to the
+# outpost. Without this the ext-auth redirect lands on Adminer and 404s.
+#
+# Internal gateway only, matching the app route — this host is not published
+# through the Cloudflare tunnel.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: adminer-outpost
+  namespace: database
+spec:
+  parentRefs:
+    - name: internal-gateway
+      namespace: network
+      sectionName: https-56kbps
+  hostnames:
+    - "postgres.${SECRET_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io
+      backendRefs:
+        - name: ak-outpost-56kbps
+          namespace: security
+          port: 9000

--- a/kubernetes/apps/database/adminer/app/kustomization.yaml
+++ b/kubernetes/apps/database/adminer/app/kustomization.yaml
@@ -2,11 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: database
-components:
-  - ../../components/common
 resources:
-  - ./adminer/ks.yaml
-  - ./dragonfly/ks.yaml
-  - ./mosquitto/ks.yaml
-  - ./postgres/ks.yaml
+  - ./helmrelease.yaml
+  - ./httproute-outpost.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/database/adminer/app/securitypolicy.yaml
+++ b/kubernetes/apps/database/adminer/app/securitypolicy.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# Authentik forward-auth (Envoy ext-auth) for adminer. x-forwarded-proto is
+# forwarded so the login redirect comes back as https
+# (goauthentik/authentik#19653).
+#
+# This gates reaching the page only. Adminer has no OIDC support and still
+# prompts for Postgres credentials afterwards, which is deliberate: SSO proves
+# who you are, the database role decides what you can touch, and a stolen
+# browser session alone does not grant superuser on a shared instance.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: adminer
+  namespace: database
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: adminer
+  extAuth:
+    failOpen: false
+    recomputeRoute: true
+    headersToExtAuth:
+      - X-Forwarded-For
+      - X-Real-Ip
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - kind: Service
+          name: ak-outpost-56kbps
+          namespace: security
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend:
+        - Set-Cookie
+        - X-authentik-uid
+        - X-authentik-username
+        - X-authentik-name
+        - X-authentik-email
+        - X-authentik-groups
+        - X-authentik-entitlements

--- a/kubernetes/apps/database/adminer/ks.yaml
+++ b/kubernetes/apps/database/adminer/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app adminer
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: postgres
+      namespace: database
+  path: ./kubernetes/apps/database/adminer/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  # No volsync component: adminer is entirely stateless. It holds no data of its
+  # own — connection details are typed at login and live only in the session.
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/security/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant.yaml
@@ -21,6 +21,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: observability
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: database
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: network
@@ -30,6 +33,9 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: observability
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: database
   to:
     - group: ""
       kind: Service

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -35,6 +35,13 @@ locals {
   }
 
   proxy_applications = {
+    adminer = {
+      external_host = "https://postgres.56kbps.io"
+      icon_url      = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/adminer.png"
+      group         = resource.authentik_group.observability
+      cookie_domain = "56kbps.io"
+      namespace     = "database"
+    },
     bazarr = {
       external_host   = "https://bazarr.56kbps.io"
       icon_url        = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/bazarr.png"

--- a/terraform/authentik/outposts.tf
+++ b/terraform/authentik/outposts.tf
@@ -15,6 +15,7 @@ locals {
     tonumber(authentik_provider_proxy.main["tautulli"].id),
     tonumber(authentik_provider_proxy.main["qbittorrent"].id),
     tonumber(authentik_provider_proxy.main["audiobookshelf"].id),
+    tonumber(authentik_provider_proxy.main["adminer"].id),
   ]
 
   # halfduplex outpost = BBS only (cookie domain halfduplex.io via authentik_host sso.halfduplex.io)


### PR DESCRIPTION
A modern phpMyAdmin for the shared Postgres from #1533, gated by Authentik.

## Why Adminer

pgAdmin ran here before and was removed alongside cloudnative-pg. This is deliberately the lighter replacement — Adminer is the direct phpMyAdmin descendant, a single PHP file with no state and no database of its own.

It's also the only current option of the obvious three:

| | latest | last updated |
|---|---|---|
| **adminer** (official library image) | 5.5.1 | **2026-08-03** |
| pgadmin4 | 9.17 | 2026-07-31 |
| pgweb | 0.17.0 | 2025-11-22 (~9 months) |

## Auth

Adminer has no OIDC support, so this is forward-auth via the existing Envoy `SecurityPolicy` recipe: Authentik gates reaching the page, and Adminer then prompts for Postgres credentials.

**That second step is kept on purpose.** SSO proves identity, the database role decides authority, and a stolen browser session alone does not hand out superuser on an instance that will hold Home Assistant's, lubelog's and eventually the \*arr databases. The `login-password-less` plugin would collapse both into one and is deliberately not enabled.

**Internal gateway only** — no Cloudflare tunnel route, unlike most apps here. Direct database access shouldn't be reachable from the internet even behind SSO.

## Implementation notes

- **The docroot is seeded into an emptyDir by an initContainer.** Adminer's entrypoint writes into `/var/www/html` — it symlinks the chosen design to `adminer.css` and generates a loader per plugin into `plugins-enabled/` — and runs under `set -e`. With `readOnlyRootFilesystem: true` those writes fail and the container *exits* rather than degrading. Mounting an emptyDir straight over `/var/www/html` would instead hide `adminer.php` and the 27 bundled designs, hence the copy. Verified by rendering the chart: initContainer gets `/html`, app container gets `/var/www/html`, same volume.
- **`login-reverse-proxy` is not authentication**, despite the name — I checked the plugin source. It keys brute-force throttling off `X-Forwarded-For` so failed logins aren't all attributed to the Envoy gateway's IP. Worth having behind a proxy, but it authenticates nobody.
- **uid 100 / gid 101 and port 8080** read from the image config, not assumed.
- Theme is **pepa-linha**. `ADMINER_DESIGN` swaps among the 27 bundled designs; a ConfigMap at `/var/www/html/adminer.css` overrides entirely.
- Plugins enabled: `tables-filter`, `edit-textarea`, `pretty-json-column`, `dump-json`, `sql-log`, `highlight-codemirror`, `login-reverse-proxy`.
- `ADMINER_DEFAULT_SERVER` prefills the host so only credentials are typed.

## ReferenceGrant

`security/gateway-to-outposts` gains the `database` namespace for both `HTTPRoute` and `SecurityPolicy`. Without it Envoy Gateway silently refuses the cross-namespace backendRef to the outpost and forward-auth fails closed.

## Terraform — requires apply

Adds the proxy application and registers its provider with the 56kbps outpost. Both halves matter: a provider that exists but is missing from the outpost's `protocol_providers` yields `no app for hostname` at request time, which is exactly what happened with audiobookshelf.

Group is `observability`, matching dozzle as the other ops/debugging tool. Application name renders `k8s/stonehedges.net/database/adminer`.

## Verification

- `kustomize build` on `apps/database`, `adminer/app`, and `authentik/app`
- `validate-schemas.sh` passes on the HelmRelease
- Chart rendered with `helm template` to confirm the `advancedMounts` split
- `terraform fmt -check` clean on both files touched (`source.tf` shows pre-existing drift, untouched here)
- All pre-commit hooks pass

## After merge

`terraform apply`, then `postgres.56kbps.io` on the internal network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8