### PR TITLE
fix(adminer): stop the initContainer emitting ~150 ownership warnings

### DIFF
--- a/kubernetes/apps/database/adminer/app/helmrelease.yaml
+++ b/kubernetes/apps/database/adminer/app/helmrelease.yaml
@@ -44,7 +44,14 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
-                cp -a /var/www/html/. /html/
+                set -eu
+                # cp -r, NOT cp -a. The -a implies -p, and preserving ownership
+                # of root-owned files as uid 100 fails on every single one —
+                # ~150 lines of "cp: can't preserve ownership" per pod start.
+                # The copy itself succeeded, but the log looked like a failure.
+                # Nothing here needs its original uid/gid: PHP only has to read
+                # the files, and the entrypoint writes as the same user.
+                cp -r /var/www/html/. /html/
                 echo "seeded docroot: $(ls -1 /html | wc -l) entries"
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Cosmetic, but the wrong signal to leave behind. Found while verifying the deploy from #1537.

## Problem

The docroot seed used `cp -a`, which implies `-p`. Preserving ownership of root-owned image files as uid 100 fails for every single entry, so each pod start logs ~150 lines of:

```
cp: can't preserve ownership of '/html/./designs/dracula': Operation not permitted
cp: can't preserve ownership of '/html/./plugins/sql-log.php': Operation not permitted
...
```

The copy itself worked fine — verified on the live pod:

```
adminer.css -> designs/pepa-linha/adminer.css
plugins-enabled/  001-tables-filter.php … 007-login-reverse-proxy.php
```

But anyone reading those logs while debugging would reasonably conclude the initContainer was broken.

## Fix

`cp -r` instead of `cp -a` — copies content without attempting to preserve uid/gid. Nothing here needs the original ownership: PHP only reads these files, and the entrypoint writes as the same user that runs the server.

Also added `set -eu`, which the original was missing. A genuinely failed seed would previously have fallen through to the `echo` and reported success.

## Deploy status (unchanged by this)

The app is up and correct: pod `1/1`, HTTP 200 with `<title>Login - Adminer</title>`, pepa-linha applied, all 7 plugins loaded, `SecurityPolicy Accepted=True`, HTTPRoute `Accepted=True` + `ResolvedRefs=True` (which confirms the cross-namespace ReferenceGrant to the outpost resolved). Terraform applied: proxy provider id 22 created and present in the outpost's `protocol_providers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8