### PR TITLE
feat(lubelog): re-enable on the shared postgres

### DIFF
--- a/kubernetes/apps/database/adminer/app/helmrelease.yaml
+++ b/kubernetes/apps/database/adminer/app/helmrelease.yaml
@@ -44,7 +44,14 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
               - |
-                cp -a /var/www/html/. /html/
+                set -eu
+                # cp -r, NOT cp -a. The -a implies -p, and preserving ownership
+                # of root-owned files as uid 100 fails on every single one —
+                # ~150 lines of "cp: can't preserve ownership" per pod start.
+                # The copy itself succeeded, but the log looked like a failure.
+                # Nothing here needs its original uid/gid: PHP only has to read
+                # the files, and the entrypoint writes as the same user.
+                cp -r /var/www/html/. /html/
                 echo "seeded docroot: $(ls -1 /html | wc -l) entries"
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
   - ./kometa/ks.yaml
   - ./jellyseerr/ks.yaml
   - ./lidarr/ks.yaml
-# - ./lubelog/ks.yaml
+  - ./lubelog/ks.yaml
   - ./enigma-bbs/ks.yaml
 # - ./mystic-bbs/ks.yaml
 # - ./node-red/ks.yaml

--- a/kubernetes/apps/default/lubelog/app/externalsecret.yaml
+++ b/kubernetes/apps/default/lubelog/app/externalsecret.yaml
@@ -13,7 +13,14 @@ spec:
     template:
       engineVersion: v2
       data:
-        POSTGRES_CONNECTION: "Host={{ .LUBELOG_POSTGRES_HOST }};Username={{ .LUBELOG_POSTGRES_USER }};Password={{ .LUBELOG_POSTGRES_PASS }};Database={{ .LUBELOG_POSTGRES_NAME }}"
+        # Host is deliberately literal rather than {{ .LUBELOG_POSTGRES_HOST }}.
+        # That 1Password field still reads postgres16-rw.database.svc.cluster
+        # .local — the CNPG service that no longer exists — and a hostname is
+        # cluster topology, not a secret, so it belongs in git where it moves
+        # with the infrastructure. This is the same value components/postgresql
+        # hardcodes for INIT_POSTGRES_HOST; the two must agree or init-db
+        # provisions the role somewhere the app does not connect to.
+        POSTGRES_CONNECTION: "Host=postgres.database.svc.cluster.local;Username={{ .LUBELOG_POSTGRES_USER }};Password={{ .LUBELOG_POSTGRES_PASS }};Database={{ .LUBELOG_POSTGRES_NAME }}"
         MailConfig__EmailServer: "smtp-relay.default.svc.cluster.local:25"
         MailConfig__EmailFrom: "lubelog@56kbps.io"
         MailConfig__Port: "587"

--- a/kubernetes/apps/default/lubelog/ks.yaml
+++ b/kubernetes/apps/default/lubelog/ks.yaml
@@ -15,7 +15,13 @@ spec:
     - ../../../../components/volsync
     - ../../../../components/postgresql
   dependsOn:
+    # namespace is required. dependsOn defaults to the referring Kustomization's
+    # own namespace, and this one lands in default (apps/default/kustomization
+    # .yaml sets namespace: default for everything it collects), while
+    # external-secrets-stores lives in external-secrets. Without this the
+    # dependency never resolves and the Kustomization blocks indefinitely.
     - name: external-secrets-stores
+      namespace: external-secrets
   path: ./kubernetes/apps/default/lubelog/app
   prune: true
   sourceRef:


### PR DESCRIPTION
First consumer of the restored `components/postgresql` from #1533. Its `init-db` initContainer creates the lubelog role and database on the shared instance at startup, so nothing needs provisioning by hand.

Lubelog has been commented out of `apps/default/kustomization.yaml` purely because it referenced a component that no longer existed.

## Two things had to be fixed first

**1. The connection string pointed at a database that no longer exists.**

`LUBELOG_POSTGRES_HOST` in 1Password still reads:

```
postgres16-rw.database.svc.cluster.local
```

— the CNPG service removed with the operator. Rather than edit the 1Password item, the host is now literal in the ExternalSecret. A hostname is cluster topology, not a secret, so it belongs in git where it moves with the infrastructure. It also has to match the `INIT_POSTGRES_HOST` that `components/postgresql` hardcodes, or `init-db` provisions the role somewhere the app never connects to — keeping both in the repo makes that agreement checkable. Verified in the rendered output that they now agree.

**2. `dependsOn` on `external-secrets-stores` was missing its namespace.**

`dependsOn` defaults to the referring Kustomization's own namespace. This app's lands in `default` (set by `apps/default/kustomization.yaml`), while `external-secrets-stores` lives in `external-secrets`. The dependency would never have resolved and the Kustomization would have blocked indefinitely — the app would simply never have deployed, with no obvious error.

## Latent elsewhere

Every other app carrying that same missing-namespace bug is currently **dormant**:

`rtlamr2mqtt`, `homeassistant`, `bsky-pds`, `smtp-relay`, `node-red`, `ultrafeeder`, `zigbee2mqtt`

No live app has it. Each needs the same one-line fix when re-enabled — **homeassistant included**, which is next.

## Preflight

Checked against the live 1Password store before committing, so this shouldn't fail on secrets:

- `lubelog` item has `LUBELOG_POSTGRES_{USER,PASS,NAME}` and the username/password hashes
- `LUBELOG_CLIENT_ID` / `LUBELOG_CLIENT_SECRET` are in the `authentik` item (both present)
- `postgresql` item supplies `POSTGRES_SUPER_PASS` for `init-db`

Image is already on the newest published tag (v1.7.0) — 61 tags checked — so no upgrade rides along.

## Verification

- `kustomize build` on `apps/default` and `lubelog/app`
- Component rendered against the app: `init-db` present on `postgres-init:18`, HelmRelease `dependsOn: postgres/database`, and `POSTGRES_CONNECTION` / `INIT_POSTGRES_HOST` both resolving to `postgres.database.svc.cluster.local`
- All pre-commit hooks pass

Lubelog already has an Authentik OAuth2 provider (it was one of the four drift items in the last apply), so no terraform change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8