### PR TITLE
fix(cloudflared): add lubelog to the tunnel ingress

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/configs/config.yaml
@@ -76,6 +76,10 @@ ingress:
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:
       originServerName: "lidarr.56kbps.io"
+  - hostname: "lubelog.56kbps.io"
+    service: https://external-gateway.network.svc.cluster.local:443
+    originRequest:
+      originServerName: "lubelog.56kbps.io"
   - hostname: "prowlarr.56kbps.io"
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:


### PR DESCRIPTION
`lubelog.56kbps.io` returned 404 after the app was re-enabled in #1539.

## Diagnosis

The app was healthy the entire time. Hit directly on its service:

```
/        HTTP 302  ->  /Login/Index
/Login   HTTP 200
```

Pod `1/1 Running`, Kustomization reconciled, HTTPRoute present with the right hostname, and DNS resolving to Cloudflare (`104.21.7.171`, `172.67.187.242` — identical to working apps like bazarr).

The 404 was the **tunnel's own catch-all** firing:

```yaml
  - service: http_status:404
```

No ingress rule matched `lubelog.56kbps.io`, so cloudflared returned its fallback. Getting that 404 rather than a 522 is itself the tell — traffic was reaching the tunnel fine, the tunnel just had nowhere to send it.

## Fix

Adds the missing ingress entry, matching the other externally-published apps.

## Worth knowing

This list is **separate from the HTTPRoute**. Attaching a route to `external-gateway` is not by itself enough to publish an app — it also needs an entry here. That's easy to miss when bringing a dormant app back, because the route looks correct and the app looks healthy; nothing in Kubernetes reports a problem.

I checked whether the missing `external-dns.alpha.kubernetes.io/target` annotation was to blame, since lubelog lacks it and bazarr has it. **It isn't** — jellyfin, plex, wizarr, seerr, jellyseerr, gatus, dozzle and kromgo all omit it too and work fine. What every working external app has in common is being in this list, not the annotation. Left alone rather than changing something that isn't broken.

cloudflared already carries `reloader.stakater.com/auto`, so the configmap change rolls the pods without intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8