### PR TITLE
fix(gatus): repair stale halfduplex.io targets, drop inverted DNS check

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/default/audiobookshelf/ks.yaml
@@ -32,7 +32,6 @@ spec:
       # endpoint must be told the real subdomain or it probes a host that
       # does not exist.
       GATUS_SUBDOMAIN: books
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "31 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1035"

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "33 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1034"

--- a/kubernetes/apps/default/enigma-bbs/ks.yaml
+++ b/kubernetes/apps/default/enigma-bbs/ks.yaml
@@ -37,4 +37,5 @@ spec:
       VOLSYNC_GID: "1000"
       VOLSYNC_FSGROUP: "1000"
       GATUS_SUBDOMAIN: enigma
+      GATUS_DOMAIN: halfduplex.io # the BBS genuinely still lives on halfduplex.io
       GATUS_PATH: /

--- a/kubernetes/apps/default/homarr/ks.yaml
+++ b/kubernetes/apps/default/homarr/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/external
+    - ../../../../components/gatus/guarded # internal-gateway only; needs the internal resolver
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets-stores

--- a/kubernetes/apps/default/jellyseerr/ks.yaml
+++ b/kubernetes/apps/default/jellyseerr/ks.yaml
@@ -25,7 +25,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_SUBDOMAIN: jelly
       GATUS_PATH: /api/v1/status
       VOLSYNC_SCHEDULE: "39 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "24 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1033"

--- a/kubernetes/apps/default/lubelog/ks.yaml
+++ b/kubernetes/apps/default/lubelog/ks.yaml
@@ -34,5 +34,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_STATUS: "302" # unauthenticated / redirects to /Login
       VOLSYNC_SCHEDULE: "18 1 * * *"
       VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -28,6 +28,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "51 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       GATUS_SUBDOMAIN: qbittorrent
       VOLSYNC_SCHEDULE: "15 0 * * *"
       VOLSYNC_CAPACITY: 10Gi

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "18 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_CACHE_CAPACITY: 10Gi

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       GATUS_SUBDOMAIN: sab
       VOLSYNC_SCHEDULE: "0 1 * * *"
       VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -28,7 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "21 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1029"

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -25,6 +25,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_DOMAIN: halfduplex.io
       VOLSYNC_SCHEDULE: "45 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/components/gatus/external/configmap.yaml
+++ b/kubernetes/components/gatus/external/configmap.yaml
@@ -10,7 +10,7 @@ data:
     endpoints:
       - name: "${APP}"
         group: external
-        url: "https://${GATUS_SUBDOMAIN:-${APP}}.${SECRET_DOMAIN}${GATUS_PATH:-/}"
+        url: "https://${GATUS_SUBDOMAIN:-${APP}}.${GATUS_DOMAIN:-${SECRET_DOMAIN}}${GATUS_PATH:-/}"
         interval: 1m
         client:
           dns-resolver: tcp://1.1.1.1:53

--- a/kubernetes/components/gatus/guarded/configmap.yaml
+++ b/kubernetes/components/gatus/guarded/configmap.yaml
@@ -21,17 +21,3 @@ data:
           - "[STATUS] == ${GATUS_STATUS:-200}"
         alerts:
           - type: pushover
-      - name: "${APP}-dns"
-        group: guarded
-        url: 1.1.1.1
-        interval: 1m
-        ui:
-          hide-hostname: true
-          hide-url: true
-        dns:
-          query-name: "${GATUS_SUBDOMAIN:-${APP}}.${GATUS_DOMAIN:-${SECRET_DOMAIN}}"
-          query-type: A
-        conditions:
-          - "len([BODY]) == 0"
-        alerts:
-          - type: pushover


### PR DESCRIPTION
14 of 35 Gatus endpoints were failing. Verified against the live `/api/v1/endpoints/statuses` before and after.

## Stale `halfduplex.io` targets

Nine apps carried `GATUS_DOMAIN: halfduplex.io` in their `ks.yaml` but have served on `*.56kbps.io` since the domain swap in a45d9d29, so every probe died with `no such host`:

```
guarded/sonarr   false  sonarr.halfduplex.io  [STATUS] (0) == 200
  Get "https://sonarr.halfduplex.io/": dial tcp: lookup sonarr.halfduplex.io
  on 10.43.0.10:53: no such host
```

…same for `audiobookshelf, bazarr, lidarr, prowlarr, qbittorrent, radarr, sabnzbd, tautulli`. The override is dropped so the `${SECRET_DOMAIN}` default applies.

## The `-dns` endpoint was inverted, not redundant

Removed `${APP}-dns` from `components/gatus/guarded`. It looked like a duplicate availability check, but:

```yaml
conditions:
  - "len([BODY]) == 0"     # asserts the name does NOT resolve on 1.1.1.1
```

That's a DNS-*leak* detector, and its signal had inverted:

| endpoint | live result | why |
|---|---|---|
| `sonarr-dns` … `tautulli-dns` | ✅ green | only because `*.halfduplex.io` is dead |
| `jellyfin-dns` | ❌ red | because `jellyfin.56kbps.io` correctly resolves publicly |

Green when broken, red when correct. Fixing the domain would have flipped all nine to red and paged over each. Rewriting it as a real resolve check would make it genuinely redundant — the HTTP check already fails on DNS failure, which is exactly how these nine outages surfaced.

## Four unrelated breakages found along the way

| app | was | now |
|---|---|---|
| `jellyseerr` | probed `jelly.56kbps.io` → 404; that host routes to **jellyfin**, its own route is `jellyseerr.56kbps.io` | dropped `GATUS_SUBDOMAIN` |
| `lubelog` | expected 200, origin returns **302** to `/Login` | `GATUS_STATUS: "302"` |
| `homarr` | internal-gateway only but used the `external` component → resolved against 1.1.1.1, NXDOMAIN | moved to `guarded` (internal resolver) |
| `enigma-bbs` | probed `enigma.56kbps.io` → 404 | `GATUS_DOMAIN: halfduplex.io`; added the same escape hatch to the `external` component that `guarded` already had |

## halfduplex.io is **not** retired

This is a stale-override cleanup, not a domain retirement. The BBS still legitimately owns the apex plus `enigma.`, `edit.`, `draw.`, `wss.`, `telnet.`, `ssh.` and `mailer.`; both gateways hold listeners and certs for it; `sso.` is dual-homed across both domains. Gateway, cloudflared and external-dns config are untouched.

## Verification

- `task validate:quick` — all kustomizations build ✓
- `task validate:flux` — 177 passed ✓
- Each new target probed out-of-band through the gateway: `lubelog` 302, `jellyseerr` 200, `homarr` 200; the rest have confirmed live HTTPRoutes on `*.56kbps.io`

Net: **35 endpoints → 24**, all expected green.

### Known gap, deliberately left alone

`mystic-bbs` has a gatus component but no HTTPRoute at all, so it would probe a nonexistent `mystic-bbs.56kbps.io`. It's currently commented out of `apps/default/kustomization.yaml`, so it's dormant rather than broken — it'll need a `GATUS_*` override or component removal whenever it's re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
