### PR TITLE
fix(gatus): split guarded checks so Authentik cannot fake a green

### DIFF
--- a/kubernetes/apps/default/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/default/audiobookshelf/ks.yaml
@@ -32,6 +32,7 @@ spec:
       # endpoint must be told the real subdomain or it probes a host that
       # does not exist.
       GATUS_SUBDOMAIN: books
+      GATUS_SVC_PATH: /healthcheck
       VOLSYNC_SCHEDULE: "31 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1035"

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -28,6 +28,8 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PORT: "6767"
+      GATUS_SVC_PATH: /health
       VOLSYNC_SCHEDULE: "33 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1034"

--- a/kubernetes/apps/default/homarr/ks.yaml
+++ b/kubernetes/apps/default/homarr/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded # internal-gateway only; needs the internal resolver
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets-stores

--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: intel-device-plugin-gpu

--- a/kubernetes/apps/default/lidarr/ks.yaml
+++ b/kubernetes/apps/default/lidarr/ks.yaml
@@ -28,6 +28,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: /ping
       VOLSYNC_SCHEDULE: "24 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1033"

--- a/kubernetes/apps/default/lubelog/ks.yaml
+++ b/kubernetes/apps/default/lubelog/ks.yaml
@@ -34,6 +34,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_STATUS: "302" # unauthenticated / redirects to /Login
       VOLSYNC_SCHEDULE: "18 1 * * *"
       VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/default/node-red/ks.yaml
+++ b/kubernetes/apps/default/node-red/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: emqx-cluster

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -28,5 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: /ping
       VOLSYNC_SCHEDULE: "51 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -28,6 +28,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      # qbittorrent's only probe is a tcpSocket and its API needs auth, so the
+      # in-cluster check falls back to the WebUI root serving a 200.
+      GATUS_SVC_PATH: /
       GATUS_SUBDOMAIN: qbittorrent
       VOLSYNC_SCHEDULE: "15 0 * * *"
       VOLSYNC_CAPACITY: 10Gi

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets-stores

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -28,6 +28,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: /ping
       VOLSYNC_SCHEDULE: "18 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_CACHE_CAPACITY: 10Gi

--- a/kubernetes/apps/default/romm/ks.yaml
+++ b/kubernetes/apps/default/romm/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets-stores

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -28,6 +28,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: "/api?mode=version"
       GATUS_SUBDOMAIN: sab
       VOLSYNC_SCHEDULE: "0 1 * * *"
       VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -28,6 +28,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: /ping
       VOLSYNC_SCHEDULE: "21 0 * * *"
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_UID: "1029"

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -25,5 +25,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      GATUS_SVC_PATH: /status
       VOLSYNC_SCHEDULE: "45 0 * * *"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/default/zigbee2mqtt/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/internal
     - ../../../../components/volsync
   dependsOn:
     - name: emqx-cluster

--- a/kubernetes/components/gatus/guarded/configmap.yaml
+++ b/kubernetes/components/gatus/guarded/configmap.yaml
@@ -8,16 +8,36 @@ metadata:
 data:
   config.yaml: |
     endpoints:
+      # Is the app itself alive? Probed in-cluster over the ClusterIP, which
+      # bypasses the gateway and Authentik entirely. The path is the app's own
+      # liveness-probe path, so it is guaranteed unauthenticated.
       - name: "${APP}"
         group: guarded
-        url: "https://${GATUS_SUBDOMAIN:-${APP}}.${GATUS_DOMAIN:-${SECRET_DOMAIN}}${GATUS_PATH:-/}"
+        url: "http://${GATUS_SVC:-${APP}}.${GATUS_SVC_NS:-default}.svc.cluster.local:${GATUS_SVC_PORT:-80}${GATUS_SVC_PATH:-/}"
         interval: 1m
+        ui:
+          hide-hostname: false
+          hide-url: false
+        conditions:
+          - "[STATUS] == ${GATUS_STATUS:-200}"
+        alerts:
+          - type: pushover
+      # Is the public path still fronted by Authentik? follow-redirects is off
+      # deliberately: with it on, gatus walks the redirect chain all the way to
+      # the Authentik login page and grades *that* 200 -- which is green whether
+      # or not the app behind it is alive. Asserting the 302 challenge instead
+      # proves gateway + ext-auth + outpost without pretending to prove the app.
+      - name: "${APP}-edge"
+        group: edge
+        url: "https://${GATUS_SUBDOMAIN:-${APP}}.${GATUS_DOMAIN:-${SECRET_DOMAIN}}${GATUS_PATH:-/}"
+        interval: 5m
         ui:
           hide-hostname: false
           hide-url: false
         client:
           dns-resolver: tcp://10.1.0.1:53
+          follow-redirects: false
         conditions:
-          - "[STATUS] == ${GATUS_STATUS:-200}"
+          - "[STATUS] == ${GATUS_EDGE_STATUS:-302}"
         alerts:
           - type: pushover

--- a/kubernetes/components/gatus/internal/configmap.yaml
+++ b/kubernetes/components/gatus/internal/configmap.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${APP}-gatus-ep"
+  labels:
+    gatus.io/enabled: "true"
+data:
+  config.yaml: |
+    endpoints:
+      # Reachable on the internal gateway only, and not behind Authentik, so a
+      # plain 200 through the front door is honest signal on its own.
+      - name: "${APP}"
+        group: internal
+        url: "https://${GATUS_SUBDOMAIN:-${APP}}.${GATUS_DOMAIN:-${SECRET_DOMAIN}}${GATUS_PATH:-/}"
+        interval: 1m
+        ui:
+          hide-hostname: false
+          hide-url: false
+        client:
+          dns-resolver: tcp://10.1.0.1:53
+        conditions:
+          - "[STATUS] == ${GATUS_STATUS:-200}"
+        alerts:
+          - type: pushover

--- a/kubernetes/components/gatus/internal/kustomization.yaml
+++ b/kubernetes/components/gatus/internal/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./configmap.yaml


### PR DESCRIPTION
Follow-up to #1543, which shipped two mistakes of mine. Answers "can Gatus authenticate against Authentik, or is it just being prompted for auth?" — it was being prompted, and grading the prompt as a pass.

## Authentik was faking a green

Gatus follows redirects by default. For an Authentik-protected app that means it walks the whole chain and grades the **login page**:

```
sonarr → 302 → sso.56kbps.io/if/flow/authentication-flow/… → 200
               <title>STONEHEDGES</title>
```

`[STATUS] == 200` passes. Sonarr could be entirely down and the check would stay green. #1543 fixed the hostnames these checks pointed at, so it would have turned nine `no such host` reds into nine meaningless greens.

## Split the concern instead of teaching Gatus to log in

Authentik *does* support programmatic auth (service account + app password over `Authorization: Basic`, and the `SecurityPolicy` already forwards `authorization` to ext-auth). But that buys one ambiguous signal, costs a credential, and runs a full OAuth2 m2m flow every interval. Two honest endpoints are better than one that conflates:

| endpoint | target | proves |
|---|---|---|
| `${APP}` | `http://<svc>.default.svc.cluster.local:<port><path>` | the app is alive — bypasses gateway and Authentik entirely |
| `${APP}-edge` | public URL, `follow-redirects: false`, `[STATUS] == 302` | gateway + ext-auth + outpost are still in front of it |

The in-cluster path is each app's **own liveness-probe path**, so it's guaranteed unauthenticated and guaranteed to be a real health signal:

```
sonarr/radarr/lidarr/prowlarr  :80   /ping
bazarr                         :6767 /health
sabnzbd                        :80   /api?mode=version
tautulli                       :80   /status
audiobookshelf                 :80   /healthcheck
qbittorrent                    :80   /      (tcpSocket probe only — see below)
```

## `guarded` now means what it says

Only nine apps actually have a `SecurityPolicy`. `jellyfin`, `qui`, `romm`, `homarr`, `node-red` and `zigbee2mqtt` were in the `guarded` component purely to get the internal DNS resolver, and return 200 unauthenticated — verified:

```
qui   200      romm  200      homarr 200
jellyfin 302 → /web/ (its own redirect, not auth)
```

They get a new `components/gatus/internal` instead, rather than an auth assertion that doesn't apply to them.

## Reverts the bad lubelog fix from #1543

`GATUS_STATUS: "302"` was wrong twice over: Gatus follows redirects so it never sees the 302, and the real cause of the 404 was a missing cloudflared ingress rule — since fixed independently by #1540. With that rule live, the check resolves to 200 via `/Login/Index`, so the override has to go or lubelog stays red. Dropped; no cloudflared change here.

## Verification

- `task validate:quick` ✓ · `task validate:flux` — 177 passed ✓
- Rendered every endpoint through Flux's `${VAR:-default}` semantics to confirm final URLs (`http://bazarr.default.svc.cluster.local:6767/health`, `https://sab.56kbps.io/`, etc.)
- In-cluster probes confirmed 200 on `/ping`, `/api?mode=version`, `/status`, `/healthcheck`

**One unverified assumption:** `qbittorrent` has only a `tcpSocket` probe and its API needs auth, so its check falls back to the WebUI root returning 200. I could not confirm that live — the API server VIP `10.1.100.100:6443` went unreachable partway through (gateway on `.200:443` still answering), so this one is derived from the manifest rather than observed. Worth a glance once the cluster is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
