### PR TITLE
feat(homeassistant): re-enable on the shared postgres

### DIFF
--- a/kubernetes/apps/default/homeassistant/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homeassistant/app/externalsecret.yaml
@@ -19,7 +19,13 @@ spec:
         HOME_ASSISTANT_LONGITUDE: "{{ .HOMEASSISTANT_LONGITUDE }}"
         HOME_ASSISTANT_PIRATE_WEATHER_API_KEY: "{{ .HOMEASSISTANT_PIRATE_WEATHER_API_KEY }}"
         HOME_ASSISTANT_PROMETHEUS: "{{ .HOMEASSISTANT_PROMETHEUS }}"
-        HOME_ASSISTANT_DATABASE_URL: "postgresql://{{.HOMEASSISTANT_POSTGRES_USER}}:{{.HOMEASSISTANT_POSTGRES_PASS}}@{{.HOMEASSISTANT_POSTGRES_HOST}}/{{.HOMEASSISTANT_POSTGRES_NAME}}"
+        # Host is literal rather than {{ .HOMEASSISTANT_POSTGRES_HOST }}: that
+        # 1Password field still reads postgres16.database.svc.cluster.local,
+        # the CNPG service removed with the operator. A hostname is cluster
+        # topology, not a secret, and it has to match the INIT_POSTGRES_HOST
+        # that components/postgresql hardcodes — otherwise init-db creates the
+        # role on one server while the recorder connects to another.
+        HOME_ASSISTANT_DATABASE_URL: "postgresql://{{.HOMEASSISTANT_POSTGRES_USER}}:{{.HOMEASSISTANT_POSTGRES_PASS}}@postgres.database.svc.cluster.local/{{.HOMEASSISTANT_POSTGRES_NAME}}"
         HOME_ASSISTANT_UNIFI_HOST: "{{.HOMEASSISTANT_UNIFI_HOST}}"
         HOME_ASSISTANT_UNIFI_USER: "{{.HOMEASSISTANT_UNIFI_USER}}"
         HOME_ASSISTANT_UNIFI_PASS: "{{.HOMEASSISTANT_UNIFI_PASS}}"

--- a/kubernetes/apps/default/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homeassistant/app/helmrelease.yaml
@@ -25,9 +25,22 @@ spec:
           reloader.stakater.com/auto: "true"
         containers:
           app:
+            # Deliberately still 2025.3.3, only the namespace changes.
+            # ghcr.io/onedr0p is abandoned — 2025.3.3 is literally its last tag,
+            # which is why Renovate has not moved this in over a year.
+            # ghcr.io/home-operations is the maintained continuation and its
+            # oldest published tag happens to be exactly 2025.3.3.
+            #
+            # Matching the version is the point: the restored config in the
+            # volsync snapshot has .HA_VERSION = 2025.3.3, and Home Assistant
+            # migrates .storage forward irreversibly on first boot. Booting
+            # straight into 2026.8.1 would migrate 28 integrations, 153 devices
+            # and 1239 entities across ~17 months of releases with no verified
+            # good state to fall back to. Come up on the matching version
+            # first, confirm the restore is healthy, then upgrade in steps.
             image:
-              repository: ghcr.io/onedr0p/home-assistant
-              tag: 2025.3.3@sha256:9e2a7177b4600653d6cb46dff01b1598189a5ae93be0b99242fbc039d32d79f1
+              repository: ghcr.io/home-operations/home-assistant
+              tag: 2025.3.3@sha256:911d89f0c6dfa54c3cc0d79bc538796259e3374fe561f2cfdbc728822bf016d7
             env:
               TZ: America/Chicago
               HOME_ASSISTANT_EXTERNAL_URL: https://hass.${SECRET_DOMAIN}

--- a/kubernetes/apps/default/homeassistant/ks.yaml
+++ b/kubernetes/apps/default/homeassistant/ks.yaml
@@ -15,8 +15,18 @@ spec:
     - ../../../../components/volsync
     - ../../../../components/postgresql
   dependsOn:
+    # namespace is required — dependsOn defaults to this Kustomization's own
+    # namespace (default, set by apps/default/kustomization.yaml) while the
+    # stores live in external-secrets. Without it the dependency never resolves
+    # and the Kustomization blocks forever with no obvious error.
     - name: external-secrets-stores
-    - name: emqx-cluster
+      namespace: external-secrets
+    # Was emqx-cluster, which does not exist — only a stale HelmRepository at
+    # kubernetes/flux/meta/repositories/helm/emqx.yaml survives, and it is not
+    # even referenced by that directory's kustomization. This cluster's MQTT
+    # broker is mosquitto, in the database namespace.
+    - name: mosquitto
+      namespace: database
   path: ./kubernetes/apps/default/homeassistant/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - ./bazarr/ks.yaml
 # - ./bsky-pds/ks.yaml
 # - ./cert-exporter/ks.yaml
-# - ./homeassistant/ks.yaml
+  - ./homeassistant/ks.yaml
   - ./homarr/ks.yaml
   - ./jellyfin/ks.yaml
   - ./kometa/ks.yaml

--- a/kubernetes/apps/network/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/configs/config.yaml
@@ -20,6 +20,10 @@ ingress:
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:
       originServerName: "plex.${SECRET_DOMAIN}"
+  - hostname: "hass.${SECRET_DOMAIN}"
+    service: https://external-gateway.network.svc.cluster.local:443
+    originRequest:
+      originServerName: "hass.${SECRET_DOMAIN}"
   - hostname: "flux-webhook.${SECRET_DOMAIN}"
     service: https://external-gateway.network.svc.cluster.local:443
     originRequest:


### PR DESCRIPTION
Dormant since the 2025-08-01 rebuild that removed cloudnative-pg and took `components/postgresql` with it.

## The config survived

7 volsync snapshots are still in R2, newest **2025-05-06** (501 MiB), holding a complete Home Assistant config:

| | |
|---|---|
| `.HA_VERSION` | **2025.3.3** |
| integrations | 28 |
| devices | 153 |
| entities | 1239 |

`.storage` is intact — `core.device_registry`, `core.entity_registry`, `core.area_registry`, `core.floor_registry`, auth, config_entries. The PVC carries a `dataSourceRef` at the ReplicationDestination, so enabling this **restores that config automatically**.

## Four separate blockers

Each would have failed silently or misleadingly:

1. **`dependsOn: emqx-cluster` pointed at nothing.** Only a stale HelmRepository survives, not even referenced by its own directory's kustomization. The broker here is **mosquitto**, in `database`.
2. **`dependsOn: external-secrets-stores` was missing its namespace** — resolves against `default` instead of `external-secrets`, so it could never be satisfied. Same latent bug lubelog had; still present in the other dormant apps.
3. **`HOMEASSISTANT_POSTGRES_HOST` in 1Password still reads `postgres16.database.svc.cluster.local`** — the CNPG service. Now literal in the ExternalSecret, matching the `INIT_POSTGRES_HOST` that `components/postgresql` hardcodes. Verified in the rendered output that they agree.
4. **`hass.56kbps.io` was absent from the cloudflared ingress**, so it would have returned the tunnel's `http_status:404` catch-all regardless of how healthy the app was — precisely what happened to lubelog. Included here so we don't reproduce that.

## Staying on 2025.3.3 on purpose

Only the image *namespace* changes. `ghcr.io/onedr0p` is abandoned — 2025.3.3 is its final tag, which is why Renovate hasn't moved this in a year — and `ghcr.io/home-operations` is the maintained continuation whose **oldest** published tag happens to be exactly 2025.3.3.

Matching the version is the whole point. The restored config was written by 2025.3.3, and Home Assistant migrates `.storage` forward **irreversibly** on first boot. Jumping straight to 2026.8.1 would migrate 1239 entities across ~17 months of releases with no verified-good state to fall back to. Come up matching, confirm the restore is healthy, then upgrade in steps as its own change.

The restic snapshots make that recoverable either way, but "recoverable" is a worse position than "never broken".

## Recorder history is gone

That lived in the CNPG database, not the config PVC, and the 2025-07-30 CNPG backup I restored earlier contains no `homeassistant` database. `init-db` creates a fresh one, so **history restarts** while automations, dashboards, devices and areas come back.

## Verification

- `kustomize build` on `apps/default`, `homeassistant/app`, `cloudflared/app`
- `validate-schemas.sh` passes on the HelmRelease
- Component rendered against the app: `init-db` present, HelmRelease `dependsOn: postgres/database`, and `INIT_POSTGRES_HOST` / `HOME_ASSISTANT_DATABASE_URL` both resolving to `postgres.database.svc.cluster.local`
- All 13 required `HOMEASSISTANT_*` fields confirmed present in 1Password
- volsync mover UID defaults to 568, matching HA's `runAsUser`
- Authentik application and outpost registration already exist — no terraform needed

## After merge

Watch the volsync restore populate the PVC before the app starts, then `init-db`, then HA. First boot will be slow — it re-initialises 28 integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8