### PR TITLE
feat(homeassistant): put the browser UI behind Authentik forward-auth

### DIFF
--- a/kubernetes/apps/default/homeassistant/app/httproute-outpost.yaml
+++ b/kubernetes/apps/default/homeassistant/app/httproute-outpost.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# The Authentik login flow is served under /outpost.goauthentik.io on the app's
+# own hostname, so it has to bypass the Home Assistant backend and go straight
+# to the outpost. Without this the ext-auth redirect lands on Home Assistant,
+# which knows nothing about that path and 404s.
+#
+# Both gateways, matching the app route — Home Assistant is reachable
+# externally through the Cloudflare tunnel as well as on the LAN, and the login
+# flow has to work from either.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homeassistant-outpost
+  namespace: default
+spec:
+  parentRefs:
+    - name: external-gateway
+      namespace: network
+      sectionName: https-56kbps
+    - name: internal-gateway
+      namespace: network
+      sectionName: https-56kbps
+  hostnames:
+    - "hass.${SECRET_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io
+      backendRefs:
+        - name: ak-outpost-56kbps
+          namespace: security
+          port: 9000

--- a/kubernetes/apps/default/homeassistant/app/kustomization.yaml
+++ b/kubernetes/apps/default/homeassistant/app/kustomization.yaml
@@ -5,4 +5,6 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute-outpost.yaml
   - ./prometheusrule.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
+++ b/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# Authentik forward-auth (Envoy ext-auth) for Home Assistant.
+# x-forwarded-proto is forwarded so the login redirect comes back as https
+# (goauthentik/authentik#19653).
+#
+# Scope, stated plainly: this protects the browser UI. It does NOT make
+# Authentik mandatory for every path. The companion app authenticates against
+# /auth/* and talks over /api/*, so those are skipped on the Authentik provider
+# (terraform/authentik/applications.tf, skip_path_regex) — and /auth is itself
+# the login surface, so anyone reaching it directly still gets Home Assistant's
+# own login form with Authentik bypassed.
+#
+# That tension is inherent, not an oversight: the companion app is a UI client,
+# so there is no path set that both keeps it working and forces every login
+# through Authentik. What this buys is Authentik in front of ordinary browser
+# access; Home Assistant's own auth remains the control on the skipped paths,
+# which is why ip_ban and TOTP matter more now than they did on the LAN.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: homeassistant
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: homeassistant
+  extAuth:
+    failOpen: false
+    recomputeRoute: true
+    headersToExtAuth:
+      - X-Forwarded-For
+      - X-Real-Ip
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - kind: Service
+          name: ak-outpost-56kbps
+          namespace: security
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend:
+        - Set-Cookie
+        - X-authentik-uid
+        - X-authentik-username
+        - X-authentik-name
+        - X-authentik-email
+        - X-authentik-groups
+        - X-authentik-entitlements

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -89,6 +89,20 @@ locals {
       icon_url      = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/home-assistant-alt.png"
       group         = resource.authentik_group.home
       cookie_domain = "56kbps.io"
+      # The companion app is an OAuth client, not a browser session: it
+      # authenticates against /auth/* and then talks over /api/* (REST,
+      # /api/websocket, /api/webhook/<id>). Forward-auth on those paths breaks
+      # login and every push notification. The frontend/static paths are here
+      # because the app renders the login page in a webview and needs its
+      # assets to load.
+      #
+      # Consequence worth being explicit about: /auth is the login surface, so
+      # skipping it means Authentik can be bypassed by going straight there and
+      # using Home Assistant's own login. There is no path set that keeps a UI
+      # client working AND forces every login through Authentik. Home
+      # Assistant's own auth is the control on these paths — keep ip_ban on and
+      # TOTP enabled.
+      skip_path_regex = "^/(api|auth|static|frontend_latest|frontend_es5|local|media|service_worker\\.js|manifest\\.json)([/?].*)?"
     },
     lidarr = {
       external_host   = "https://lidarr.56kbps.io"


### PR DESCRIPTION
Home Assistant has been internet-facing with only its own login in front of it. An Authentik proxy provider already existed **and was registered in the outpost** — but nothing in Kubernetes enforced it, so the application was configured and did nothing. This adds the `SecurityPolicy` and outpost route that make it real.

## What this actually protects — and what it doesn't

Stated plainly, because the alternative is a false sense of security.

**Protected:** the browser UI. `/`, `/lovelace`, `/config/*`, `/developer-tools/*` all require Authentik.

**Not protected:** `/auth/*` and `/api/*`. The companion app is an OAuth client — it authenticates against `/auth/authorize` and `/auth/token`, then talks over `/api/websocket`, `/api/webhook/<id>` and the REST API. Forward-auth on those breaks login and every push notification.

And `/auth` **is** the login surface. So anyone going straight to `https://hass.56kbps.io/auth/authorize` still gets Home Assistant's own login form with Authentik bypassed.

That tension is inherent, not an oversight: **the companion app is a UI client, so no path set both keeps it working and forces every login through Authentik.** What this buys is Authentik in front of ordinary browser access. HA's own auth remains the control on the skipped paths — which is why `ip_ban` and TOTP matter more now than they did on the LAN.

## Why no auto-login

Home Assistant still ships no SSO. Checked core's default branch:

```
homeassistant/auth/providers/
  command_line.py  homeassistant.py  insecure_example.py  trusted_networks.py
```

No OIDC, no header provider. The component everyone uses — `BeryJu/hass-auth-header`, by authentik's own author, 330 stars — is **archived**, last release v1.12 in January 2025, and every fork is a zero-star mirror.

Putting the front door of the house behind an unmaintained auth component, immediately before a 17-month version jump, isn't a trade worth making. So: two logins, Authentik then HA, with HA sessions long-lived enough that it's rare in practice.

`trusted_networks` was considered and rejected — with `use_x_forwarded_for` it keys off the real client IP so it could auto-login LAN users, but it has no relationship to Authentik and does nothing for remote or mobile.

## Skip regex, verified

```
SKIP  /api/websocket  /api/webhook/abc  /auth/authorize  /auth/token
      /static/x.js  /frontend_latest/app.js  /service_worker.js
      /manifest.json  /local/img.png
AUTH  /  /lovelace  /config/integrations  /developer-tools/state
```

Frontend/static paths are included because the app renders the login page in a webview and needs its assets to load.

## Verification

- `kustomize build` on `homeassistant/app` and `apps/default`
- `terraform fmt -check` clean
- Regex tested against the path list above
- ReferenceGrant already covers `SecurityPolicy` and `HTTPRoute` from `default` — no change needed there
- Provider already in the outpost's `protocol_providers`

## Requires terraform apply

The `skip_path_regex` is the piece that keeps the companion app working. **Merging the manifests without applying terraform will break the app**, since forward-auth would then cover `/api` and `/auth`. Apply first, or accept a window where the app can't reach HA.

## Follow-up worth doing

`ip_ban_enabled: true` and `login_attempts_threshold` in `configuration.yaml`, plus TOTP on the `sob` account. That config lives in the PVC rather than git, so it isn't in this PR — happy to apply it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8