### PR TITLE
fix(homeassistant): point the SecurityPolicy at the real HTTPRoute name

### DIFF
--- a/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
+++ b/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
@@ -25,7 +25,16 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: homeassistant
+      # homeassistant-app, NOT homeassistant. app-template names a route after
+      # the release only when there is a single route key (adminer, sabnzbd,
+      # lubelog); with more than one it suffixes the key. This app defines both
+      # app and code-server, so the routes are homeassistant-app and
+      # homeassistant-code-server.
+      #
+      # A targetRef that matches nothing is silently accepted — the policy just
+      # never attaches and every request sails through unauthenticated, looking
+      # exactly like forward-auth is "not working" rather than misconfigured.
+      name: homeassistant-app
   extAuth:
     failOpen: false
     recomputeRoute: true


### PR DESCRIPTION
Forward-auth did nothing after #1552 merged. My mistake.

## Cause

The policy targeted an HTTPRoute called `homeassistant`. That route does not exist:

```
homeassistant-app           ["hass.56kbps.io"]
homeassistant-code-server   ["hass-code.56kbps.io"]
homeassistant-outpost       ["hass.56kbps.io"]
```

app-template names a route after the release **only when there is a single route key** — which is true for adminer, sabnzbd, bazarr and lubelog, and is where I got the assumption. This app defines two keys (`app` and `code-server`), so both get the key suffixed.

## Why it looked like nothing happened

A `targetRef` that matches nothing is **accepted without complaint**. `status.ancestors` is simply empty, no warning is emitted, and every request passes through unauthenticated.

So it presents as forward-auth "not working" rather than as a misconfiguration — and for a security control, failing open and silently is the wrong way round. Worth remembering when adding a SecurityPolicy to any app with more than one route.

## Verification after merge

`hass.56kbps.io` in a browser should redirect to Authentik. The check that it's genuinely bound:

```
kubectl get securitypolicy -n default homeassistant -o jsonpath='{.status.ancestors[*].conditions[*].type}'
```

Empty output means it's still attached to nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8