### PR TITLE
feat(homeassistant): auto-login via Authentik, using built-in trusted_networks

### DIFF
--- a/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
+++ b/kubernetes/apps/default/homeassistant/app/securitypolicy.yaml
@@ -4,18 +4,21 @@
 # x-forwarded-proto is forwarded so the login redirect comes back as https
 # (goauthentik/authentik#19653).
 #
-# Scope, stated plainly: this protects the browser UI. It does NOT make
-# Authentik mandatory for every path. The companion app authenticates against
-# /auth/* and talks over /api/*, so those are skipped on the Authentik provider
-# (terraform/authentik/applications.tf, skip_path_regex) — and /auth is itself
-# the login surface, so anyone reaching it directly still gets Home Assistant's
-# own login form with Authentik bypassed.
+# This is load-bearing for authentication, not just an access gate.
 #
-# That tension is inherent, not an oversight: the companion app is a UI client,
-# so there is no path set that both keeps it working and forces every login
-# through Authentik. What this buys is Authentik in front of ordinary browser
-# access; Home Assistant's own auth remains the control on the skipped paths,
-# which is why ip_ban and TOTP matter more now than they did on the LAN.
+# configuration.yaml trusts the pod CIDR via the trusted_networks auth provider
+# with allow_bypass_login, so Home Assistant logs in — as the owner, with no
+# password — anything that reaches its login flow from this gateway. That is
+# only safe because /auth/login_flow is NOT in the Authentik provider's
+# skip_path_regex, so it cannot be reached without passing Authentik first.
+#
+# Two things must therefore stay true:
+#   - failOpen stays false. Failing open here would not degrade to "ask for a
+#     password", it would hand owner access to anyone who can reach the
+#     gateway.
+#   - the skip regex in terraform/authentik/applications.tf keeps /auth/token
+#     and /api open (the companion app needs them) while keeping
+#     /auth/login_flow, /auth/authorize and /auth/providers closed.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -89,20 +89,31 @@ locals {
       icon_url      = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/home-assistant-alt.png"
       group         = resource.authentik_group.home
       cookie_domain = "56kbps.io"
-      # The companion app is an OAuth client, not a browser session: it
-      # authenticates against /auth/* and then talks over /api/* (REST,
-      # /api/websocket, /api/webhook/<id>). Forward-auth on those paths breaks
-      # login and every push notification. The frontend/static paths are here
-      # because the app renders the login page in a webview and needs its
-      # assets to load.
+      # Split by whether the endpoint is interactive, not by prefix.
       #
-      # Consequence worth being explicit about: /auth is the login surface, so
-      # skipping it means Authentik can be bypassed by going straight there and
-      # using Home Assistant's own login. There is no path set that keeps a UI
-      # client working AND forces every login through Authentik. Home
-      # Assistant's own auth is the control on these paths — keep ip_ban on and
-      # TOTP enabled.
-      skip_path_regex = "^/(api|auth|static|frontend_latest|frontend_es5|local|media|service_worker\\.js|manifest\\.json)([/?].*)?"
+      # SKIPPED — the companion app calls these without a browser and cannot
+      # satisfy a redirect to Authentik:
+      #   /api/*        REST, /api/websocket, /api/webhook/<id>
+      #   /auth/token   access-token refresh (HomeAssistantView, requires_auth
+      #                 False) — the app hits this on a timer, so blocking it
+      #                 breaks the app hours later rather than immediately
+      #   /auth/revoke  logout
+      #   /.well-known/oauth-*   OAuth discovery
+      #
+      # PROTECTED — deliberately NOT skipped, because this is where Home
+      # Assistant decides who you are:
+      #   /auth/login_flow[/{id}]  the login flow, and where the
+      #                            trusted_networks provider grants a session
+      #   /auth/authorize          the login page
+      #   /auth/providers          provider list
+      #
+      # That split is what makes auto-login safe. configuration.yaml trusts the
+      # pod CIDR via trusted_networks with allow_bypass_login, so anything that
+      # reaches the login flow is logged straight in as the owner — which is
+      # only acceptable while the login flow itself is unreachable without
+      # Authentik. Widening this regex back to a bare "auth" would hand owner
+      # access to anyone on the internet.
+      skip_path_regex = "^/(api|auth/token|auth/revoke|\\.well-known|static|frontend_latest|frontend_es5|local|media|service_worker\\.js|manifest\\.json)([/?].*)?"
     },
     lidarr = {
       external_host   = "https://lidarr.56kbps.io"


### PR DESCRIPTION
Completes the forward-auth work: **one login, at Authentik**, instead of two. No third-party code.

## Correcting an earlier claim

I previously said auto-login required `BeryJu/hass-auth-header`, which is archived. **That was wrong.** Home Assistant's own `trusted_networks` provider with `allow_bypass_login` does it with built-ins — but only *safely* once the login flow itself sits behind Authentik, which is the part that needed working out.

## Mechanism

Authentik authenticates at the proxy. HA sees the request arrive from the Envoy gateway, matches `trusted_networks`, and issues a session for the owner account with no form.

## The skip regex is now split by interactivity, not prefix

**Skipped** — the companion app calls these without a browser and cannot satisfy a redirect:

```
/api/*                    REST, /api/websocket, /api/webhook/<id>
/auth/token               access-token refresh
/auth/revoke              logout
/.well-known/oauth-*      discovery
```

`/auth/token` matters more than it looks: the app refreshes on a timer, so blocking it breaks the app *hours later* rather than immediately — a miserable thing to debug.

**Protected** — where HA decides who you are:

```
/auth/login_flow[/{id}]   where trusted_networks grants the session
/auth/authorize           the login page
/auth/providers           provider list
```

**That split is the entire safety argument.** Widening this back to a bare `auth` would silently hand owner access to anyone on the internet.

Verified:

```
SKIP  /api/websocket  /api/webhook/x  /auth/token  /auth/revoke
      /.well-known/oauth-authorization-server  /static/*  /frontend_latest/*
AUTH  /auth/login_flow  /auth/login_flow/abc  /auth/authorize  /auth/providers
      /  /lovelace  /config/integrations
```

## Two consequences accepted deliberately

**`use_x_forwarded_for` goes off.** HA must see the gateway address rather than yours, so real client IPs disappear from its logs and `ip_ban` becomes unusable — it would ban the gateway, i.e. everyone. Acceptable *only* because the login flow is no longer reachable without Authentik, so there's nothing left to brute-force.

**`failOpen` must stay `false`.** This SecurityPolicy is now load-bearing for authentication, not just access. Failing open would no longer degrade to "ask for a password" — it would hand out owner access to anyone reaching the gateway.

Both are documented in the manifest so the next person doesn't relax them casually.

## Rollout ordering is not optional

`terraform apply` **must** land before `configuration.yaml` gains `trusted_networks`. The reverse order leaves a window where `/auth/login_flow` is still skipped *and* auto-login is live — i.e. owner access exposed to the internet.

The `configuration.yaml` change lives in the PVC rather than git, so it isn't in this PR. I'll apply it after the terraform apply, with a backup taken first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8