### PR TITLE
feat(homeassistant): restrict ingress now that pod CIDR grants owner access

### DIFF
--- a/kubernetes/apps/default/homeassistant/app/kustomization.yaml
+++ b/kubernetes/apps/default/homeassistant/app/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute-outpost.yaml
+  - ./networkpolicy.yaml
   - ./prometheusrule.yaml
   - ./securitypolicy.yaml

--- a/kubernetes/apps/default/homeassistant/app/networkpolicy.yaml
+++ b/kubernetes/apps/default/homeassistant/app/networkpolicy.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/networking.k8s.io/networkpolicy_v1.json
+# Closes the hole opened by trusted_networks auto-login.
+#
+# configuration.yaml trusts 10.42.0.0/16 — the whole pod CIDR, not just the two
+# gateway pods, because their addresses change on every restart. Without this
+# policy any pod in the cluster can POST to homeassistant.default.svc:8123
+# /auth/login_flow and be handed an owner session, bypassing Authentik
+# completely. That is not theoretical; it is exactly how the auto-login was
+# verified.
+#
+# Ingress only. Egress is deliberately NOT restricted: Home Assistant has to
+# reach MQTT, the LAN devices it controls, and assorted cloud APIs, and
+# enumerating that is a good way to break automations in ways nobody connects
+# back to a network policy months later.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: homeassistant
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: homeassistant
+  policyTypes:
+    - Ingress
+  ingress:
+    # The Envoy gateways. Traffic arriving this way on the app route has already
+    # passed the Authentik SecurityPolicy, which is what makes trusting the pod
+    # CIDR acceptable at all.
+    #
+    # 12321 is the code-server sidecar (hass-code.${SECRET_DOMAIN}, internal
+    # gateway only). Note it is NOT behind forward-auth and serves /config with
+    # --auth none, so it remains a way to read .storage/auth and bypass all of
+    # this. Allowed here only so the existing route keeps working; it wants
+    # closing separately.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: envoy-gateway
+      ports:
+        - port: 8123
+          protocol: TCP
+        - port: 12321
+          protocol: TCP
+    # homarr renders Home Assistant entities on the dashboard and holds an API
+    # token for it (HOMEPAGE_VAR_HOMEASSISTANT_TOKEN in homarr-secret). Same
+    # namespace, so a bare podSelector is the right scope.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: homarr
+      ports:
+        - port: 8123
+          protocol: TCP


### PR DESCRIPTION
Closes the hole opened by the `trusted_networks` auto-login in #1554.

## The problem

`trusted_networks` trusts `10.42.0.0/16` — the **entire pod CIDR**, not just the two gateway pods, because their addresses change on every restart. So any pod in the cluster could POST to `homeassistant.default.svc:8123/auth/login_flow` and be handed an owner session, bypassing Authentik completely.

Not theoretical — it's exactly how I verified the auto-login worked:

```
POST /auth/login_flow  ->  {"type":"create_entry", "handler":["trusted_networks",null], ...}
```

No credentials, first request, from a throwaway curl pod.

## Scope

Ingress limited to the two things that legitimately talk to it:

- **the Envoy gateways** (`network` ns, `managed-by=envoy-gateway`) — traffic on the app route has already passed the Authentik SecurityPolicy
- **homarr**, which renders HA entities and holds an API token (`HOMEPAGE_VAR_HOMEASSISTANT_TOKEN` in `homarr-secret`)

**Egress is deliberately untouched.** HA has to reach MQTT, the LAN devices it controls, and assorted cloud APIs — enumerating that is a good way to break automations in ways nobody connects back to a NetworkPolicy months later. `policyTypes` lists `Ingress` only, so egress stays unrestricted rather than defaulting to deny.

## Verified live, all three assertions

```
random pod  -> HA:8123   HTTP 000   blocked
gateway     -> hass.56kbps.io   HTTP 302 -> Authentik   still reachable
homarr pod  -> HA:8123   {"providers":[...]}   still allowed
```

HA `2/2 Running` throughout.

Selectors were checked against live pods before commit — 1 HA, 2 gateway proxies, 1 homarr — and the `network` namespace does carry the `kubernetes.io/metadata.name` label the `namespaceSelector` depends on. Neither container has probes configured, so there's no kubelet health-check traffic to starve (the classic way a NetworkPolicy turns into a CrashLoop).

## Not fixed by this

Port 12321 is allowed from the gateways so the existing code-server route keeps working. **That does not secure it**: the sidecar runs `--auth none` and serves `/config`, so it remains a way to read `.storage/auth` and bypass everything above — and being in the same pod, no NetworkPolicy can help. It wants closing separately, either behind Authentik or removed in favour of `kubectl exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8