### PR TITLE
fix(cloudflared): revert to 2026.7.3 — 2026.8.0 breaks Authentik externally

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -27,7 +27,14 @@ spec:
           app:
             image:
               repository: docker.io/cloudflare/cloudflared
-              tag: 2026.8.0
+              # PINNED — do not let Renovate move this without testing the
+              # external path end to end. 2026.8.0 (#1555, rolled out 10:29Z on
+              # 2026-08-13) broke every SSO app published through the tunnel:
+              # Authentik returned 404 for requests arriving via cloudflared
+              # while the identical URL served 302 through the internal gateway
+              # and direct to the Service. cloudflared's own log showed it
+              # relaying those 404s from the origin.
+              tag: 2026.7.3
             env:
               NO_AUTOUPDATE: true
               TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json


### PR DESCRIPTION
**Active outage.** Every SSO-protected app published through the tunnel returned 404 from the moment 2026.8.0 rolled out at 10:29Z (#1555) — sab, bazarr, radarr, prowlarr, sonarr, qbittorrent, tautulli and hass.

## Proven by rollback

```
                     2026.8.0    2026.7.3
sab.56kbps.io        404         200 (2 redirects)
bazarr.56kbps.io     404         200 (2 redirects)
radarr.56kbps.io     404         200 (2 redirects)
hass.56kbps.io       404         200 (2 redirects)
```

## Evidence the tunnel is the boundary

- The **identical** authorize URL returns **302** via the internal gateway and direct to the `authentik-server` Service, but **404** through the tunnel.
- The HTTPRoute is a plain `/` PathPrefix on both gateways, so nothing is dropping the path in Envoy.
- The 404 body carries `x-powered-by: authentik` — requests *do* reach Authentik, and Authentik returns the 404.
- cloudflared's own log shows it relaying them:
  ```
  404 Not Found ingressRule=0 originService=https://external-gateway.network.svc.cluster.local:443
  ```
- Server, worker and both outposts are all on 2026.5.6, so this isn't skew between Authentik components.

Something about how 2026.8.0 forwards to an `https` origin — most likely SNI/Host handling against `originServerName` — makes Authentik route the request differently than the same request arriving via Envoy directly.

## Why it was easy to miss

The **internal gateway kept working throughout.** From inside the cluster everything looked healthy; Gatus's internal checks would have stayed green while external ones went red. The recent `fix(gatus): split guarded checks` (#1548) is what makes that distinction visible at all.

## Pinned deliberately

Left with a comment rather than floating, so Renovate doesn't walk it forward again without someone testing the external path end to end.

## Note

I rolled the live deployment back with `kubectl set image` to restore service, but cloudflared is Helm-managed — **the next Flux reconcile will reinstate 2026.8.0 and the outage returns** until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8