### PR TITLE
fix(cloudflared): hold below 2026.8.0 with a Renovate gate, not a comment

### DIFF
--- a/.github/renovate/upgradePolicy.json5
+++ b/.github/renovate/upgradePolicy.json5
@@ -35,6 +35,27 @@
       "dependencyDashboardApproval": true,
     },
 
+    // cloudflared: hold below 2026.8.0.
+    // 2026.8.0 broke every app published through the Cloudflare tunnel.
+    // Authentik returned 404 for requests arriving via cloudflared while the
+    // identical URL served 302 through the internal gateway and direct to the
+    // Service, so nothing looked wrong from inside the cluster — only the
+    // external Gatus checks went red. Likely SNI/Host handling against
+    // originServerName when forwarding to an https origin.
+    //
+    // This is a version gate rather than a comment in the HelmRelease because a
+    // comment does not stop a bot: #1557 reverted to 2026.7.3 and Renovate
+    // re-raised the identical bump as #1558 minutes later, restoring the outage.
+    //
+    // To move past it: deploy the new version, then verify the EXTERNAL path
+    // end to end (curl -L https://sab.56kbps.io/ should finish 200 on the
+    // Authentik login, not 404). Raise or drop this bound once that passes.
+    {
+      "description": "cloudflared 2026.8.0 breaks Authentik through the tunnel — verify externally before moving",
+      "matchPackageNames": ["/^docker\\.io/cloudflare/cloudflared$/"],
+      "allowedVersions": "<2026.8.0",
+    },
+
     // PostgreSQL majors: do not raise PRs at all.
     // The data directory is written by a specific major and a new server
     // refuses to open it, so the upgrade is a planned maintenance task

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -27,14 +27,14 @@ spec:
           app:
             image:
               repository: docker.io/cloudflare/cloudflared
-              # PINNED — do not let Renovate move this without testing the
-              # external path end to end. 2026.8.0 (#1555, rolled out 10:29Z on
-              # 2026-08-13) broke every SSO app published through the tunnel:
-              # Authentik returned 404 for requests arriving via cloudflared
-              # while the identical URL served 302 through the internal gateway
-              # and direct to the Service. cloudflared's own log showed it
-              # relaying those 404s from the origin.
-              tag: 2026.8.0
+              # Held at 2026.7.3 — 2026.8.0 breaks Authentik for every app
+              # published through the tunnel (404 from Authentik on requests
+              # arriving via cloudflared, while the identical URL serves 302
+              # through the internal gateway). Enforced in
+              # .github/renovate/upgradePolicy.json5 — a comment alone did not
+              # stop it: #1557 reverted this and Renovate re-raised the same
+              # bump as #1558 within minutes.
+              tag: 2026.7.3
             env:
               NO_AUTOUPDATE: true
               TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json


### PR DESCRIPTION
#1557 reverted cloudflared to 2026.7.3. Renovate re-raised the identical bump as **#1558** minutes later, it merged, Flux applied it, and every app behind the tunnel went back to 404. **The revert lasted about twenty minutes.**

```
0a8576b4  update cloudflared 2026.7.3 -> 2026.8.0  (#1558)   <- undid the fix
9c4c6f8f  revert to 2026.7.3                        (#1557)   <- the fix
7207e316  update cloudflared 2026.7.3 -> 2026.8.0  (#1555)   <- original break
```

## What I got wrong in #1557

I "pinned" it with a code comment reading *"do not let Renovate move this without testing the external path"*. **Renovate does not read prose.** That was documentation of an intent, not enforcement of it.

This repo already has the right mechanism — `upgradePolicy.json5` gates rook-ceph minors and postgres majors for exactly this class of problem, each with the incident written up. The rule belonged there from the start.

`allowedVersions: "<2026.8.0"` stops the PR being raised at all, rather than relying on someone spotting what they're merging at 2am. Patch releases below the bound still flow normally.

Validated with `renovate-config-validator` — *Config validated successfully*.

## The underlying failure

2026.8.0 makes Authentik return **404** for requests arriving through cloudflared, while the **identical URL** serves **302** via the internal gateway and direct to the Service. Most likely SNI/Host handling against `originServerName` when forwarding to an `https` origin.

Nothing looks wrong from inside the cluster, which is what made it hard to spot: internal Gatus checks stay green while external ones go red. #1548's guarded-check split is what makes that visible at all.

## Moving past it later

Deploy the newer version, then verify the **external** path end to end:

```
curl -L https://sab.56kbps.io/     # must finish 200 on the Authentik login, not 404
```

Then raise or drop the bound.

## After merge

Flux will roll cloudflared back to 2026.7.3 and the tunnel apps recover. Worth confirming with the curl above rather than assuming — that's twice now this has looked fixed and wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8