### PR TITLE
fix(homeassistant): skip the frontend service worker, which caused the redirect loop

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -99,6 +99,13 @@ locals {
       #                 breaks the app hours later rather than immediately
       #   /auth/revoke  logout
       #   /.well-known/oauth-*   OAuth discovery
+      #   /sw-*.js      the frontend's service worker (sw-modern.js and
+      #                 sw-legacy.js). This one caused a redirect loop: a
+      #                 service worker that gets 302'd to Authentik intercepts
+      #                 subsequent navigations, so the browser bounces forever.
+      #                 An earlier version of this regex listed service_worker
+      #                 .js, which Home Assistant does serve but is not what
+      #                 the frontend actually registers.
       #
       # PROTECTED — deliberately NOT skipped, because this is where Home
       # Assistant decides who you are:
@@ -113,7 +120,7 @@ locals {
       # only acceptable while the login flow itself is unreachable without
       # Authentik. Widening this regex back to a bare "auth" would hand owner
       # access to anyone on the internet.
-      skip_path_regex = "^/(api|auth/token|auth/revoke|\\.well-known|static|frontend_latest|frontend_es5|local|media|service_worker\\.js|manifest\\.json)([/?].*)?"
+      skip_path_regex = "^/(api|auth/token|auth/revoke|\\.well-known|static|frontend_latest|frontend_es5|local|media|sw-[a-z0-9-]+\\.js|service_worker\\.js|manifest\\.json)([/?].*)?"
     },
     lidarr = {
       external_host   = "https://lidarr.56kbps.io"


### PR DESCRIPTION
The "too many redirects" was the **service worker**.

Home Assistant registers `/sw-modern.js` (and `/sw-legacy.js`). Neither matched the skip regex, so forward-auth `302`'d them to Authentik. A service worker intercepts subsequent navigations — so once it's serving an Authentik redirect instead of JavaScript, the browser bounces indefinitely.

## The outpost log, once the path is visible

```
17:40:17  callback?X-authentik-auth-callback
17:40:18  auth/envoy/sw-modern.js
17:40:21  callback?X-authentik-auth-callback
17:40:22  auth/envoy/sw-modern.js
```

Round and round — while **Authentik was behaving correctly throughout**. The browser's own requests to `/application/o/authorize/` returned `302` with `user=sob` already resolved, twice, four seconds apart. That's why every server-side check I ran came back clean: nothing *was* wrong with Authentik, HA, the routes or the policy.

## The mistake

The earlier regex listed `service_worker.js` — a filename I assumed rather than checked. Home Assistant *does* serve that path, so probing it returned `200` and it looked right. But it isn't what the frontend registers.

Now matched by pattern rather than by guessing filenames:

```
sw-[a-z0-9-]+\.js
```

The modern/legacy split is a frontend build detail that can change; a pattern survives that, a hardcoded list doesn't.

## Verified against the running instance

```
/sw-modern.js       200 from HA   -> now SKIP
/sw-legacy.js       200 from HA   -> now SKIP
/service_worker.js  200 from HA   -> still SKIP
/auth/login_flow                  -> still AUTH
/auth/authorize                   -> still AUTH
/auth/providers                   -> still AUTH
/  /lovelace  /config/integrations -> still AUTH
```

The security boundary is unchanged: the login flow stays behind Authentik, which is what makes `trusted_networks` auto-login safe.

## Requires terraform apply

The regex lives on the Authentik provider, so this needs an apply before the loop clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibmApwPpoxpZEGVtffLg8